### PR TITLE
ECL tab for Job Details

### DIFF
--- a/client-reactjs/src/components/application/JobDetails.js
+++ b/client-reactjs/src/components/application/JobDetails.js
@@ -6,13 +6,14 @@ import { hasEditPermission } from "../common/AuthUtil.js";
 import { fetchDataDictionary, eclTypes } from "../common/CommonUtil.js"
 import {omitDeep} from '../common/CommonUtil.js';
 import EditableTable from "../common/EditableTable.js"
+import { EclEditor } from "../common/EclEditor.js"
 import {handleJobDelete} from "../common/WorkflowUtil";
 
 const TabPane = Tabs.TabPane;
 const Option = Select.Option;
 const { confirm } = Modal;
 
-class JobDetails extends Component { 
+class JobDetails extends Component {
 
   state = {
     visible: true,
@@ -40,6 +41,7 @@ class JobDetails extends Component {
       name:"",
       title:"",
       description:"",
+      ecl: "",
       entryBWR:"",
       jobType: this.props.selectedJobType ? this.props.selectedJobType : '',
       gitrepo:"",
@@ -85,6 +87,7 @@ class JobDetails extends Component {
             name: data.name,
             title: (data.title == '' ? data.name : data.title),
             description: data.description,
+            ecl: data.ecl,
             gitrepo: data.gitRepo,
             entryBWR: data.entryBWR,
             jobType: data.jobType,
@@ -105,7 +108,7 @@ class JobDetails extends Component {
       .catch(error => {
         console.log(error);
       });
-    } 
+    }
   }
 
   getClusters() {
@@ -156,7 +159,7 @@ class JobDetails extends Component {
       });
     }
 
-  showModal = () => {    
+  showModal = () => {
     this.setState({
       visible: true,
     });
@@ -170,16 +173,16 @@ class JobDetails extends Component {
 
   async fetchDataDefinitions() {
     try {
-      let dataDefn = await fetchDataDictionary(this.props.applicationId);  
+      let dataDefn = await fetchDataDictionary(this.props.applicationId);
       this.setState({
         dataDefinitions: dataDefn
       });
     } catch (err) {
       console.log(err)
-    }    
+    }
   }
 
-  setInputParamsData = (data) => {    
+  setInputParamsData = (data) => {
     console.log('setInputParamsData..'+JSON.stringify(data))
     let omitResults = omitDeep(data, 'id')
     this.setState({
@@ -204,12 +207,13 @@ class JobDetails extends Component {
       selectedInputFile:"",
       clusters:[],
       selectedCluster:"",
-      jobSearchSuggestions:[],      
+      jobSearchSuggestions:[],
       job: {
         id:"",
         name:"",
         title:"",
         description:"",
+        ecl: "",
         entryBWR:"",
         jobType: this.props.selectedJobType ? this.props.selectedJobType : '',
         gitrepo:"",
@@ -292,11 +296,13 @@ class JobDetails extends Component {
           name: jobInfo.Jobname,
           title: jobInfo.Jobname,
           description: jobInfo.description,
+          ecl: jobInfo.ecl,
           entryBWR: jobInfo.entryBWR
         }
       })
       this.props.form.setFieldsValue({
-        name: jobInfo.Jobname
+        name: jobInfo.Jobname,
+        jobEcl: jobInfo.ecl
       });
 
       return jobInfo;
@@ -345,7 +351,7 @@ class JobDetails extends Component {
           if(_self.props.onDelete) {
             _self.props.onDelete(_self.props.currentlyEditingNode)
           } else {
-            _self.props.onRefresh()  
+            _self.props.onRefresh()
           }
           _self.props.onClose();
           message.success("Job deleted sucessfully");
@@ -355,7 +361,7 @@ class JobDetails extends Component {
         });
       },
       onCancel() {},
-    });    
+    });
   }
 
   saveJobDetails() {
@@ -404,6 +410,7 @@ class JobDetails extends Component {
         "name" : this.state.job.name,
         "title" : this.state.job.title,
         "description" : this.state.job.description,
+        "ecl" : this.state.job.ecl,
         "gitRepo" : this.state.job.gitrepo,
         "entryBWR" : this.state.job.entryBWR,
         "jobType" : this.state.job.jobType,
@@ -508,6 +515,11 @@ class JobDetails extends Component {
       },
     };
 
+    const eclItemLayout = {
+      labelCol: { xs: { span: 2 }, sm: { span: 2 }, md: { span: 2 }, lg: { span: 2 } },
+      wrapperCol: { xs: { span: 4 }, sm: { span: 19 }, md: { span: 19 }, lg: { span: 19 }, xl: { span: 19 } }
+    };
+
     const threeColformItemLayout = {
       labelCol: {
         xs: { span: 4 },
@@ -546,8 +558,8 @@ class JobDetails extends Component {
         width: '30%'
       }];
 
-    const {name, title, description, entryBWR, gitrepo, jobType, inputParams, outputFiles, inputFiles, contact, author } = this.state.job;
-   
+    const {name, title, description, ecl, entryBWR, gitrepo, jobType, inputParams, outputFiles, inputFiles, contact, author } = this.state.job;
+
     //render only after fetching the data from the server
     if(!name && !this.props.selectedAsset && !this.props.isNew) {
       return null;
@@ -574,145 +586,146 @@ class JobDetails extends Component {
             </Button>,
           ]}
         >
-        <Tabs
-          defaultActiveKey="1"
-        >
-          <TabPane tab="Basic" key="1">
-
-           <Form layout="vertical">
-            {/*{this.props.isNewIndex ?*/}
-            <div>
-            <Form.Item {...formItemLayout} label="Cluster">
-               <Select placeholder="Select a Cluster" onChange={this.onClusterSelection} style={{ width: 190 }} disabled={!editingAllowed}>
-                {clusters.map(cluster => <Option key={cluster.id}>{cluster.name}</Option>)}
-              </Select>
-            </Form.Item>
-
-            <Form.Item {...formItemLayout} label="Job">
-              <AutoComplete
-                className="certain-category-search"
-                dropdownClassName="certain-category-search-dropdown"
-                dropdownMatchSelectWidth={false}
-                dropdownStyle={{ width: 300 }}
-                size="large"
-                style={{ width: '100%' }}
-                dataSource={jobSearchSuggestions}
-                onChange={(value) => this.searchJobs(value)}
-                onSelect={(value) => this.onJobSelected(value)}
-                placeholder="Search jobs"
-                optionLabelProp="text"
-                disabled={!editingAllowed}
-              >
-                <Input id="autocomplete_field" suffix={this.state.autoCompleteSuffix} autoComplete="off"/>
-              </AutoComplete>
-            </Form.Item>
-            </div>
-              {/*: null
-            }*/}
-
-             <Form.Item {...formItemLayout} label="Name">
-                <Input id="job_name" name="name" onChange={this.onChange} value={name} defaultValue={name} placeholder="Name" disabled={true} disabled={!editingAllowed}/>
-            </Form.Item>     
-             <Form.Item {...formItemLayout} label="Title">
-                <Input id="job_title" name="title" onChange={this.onChange} value={title} defaultValue={title} placeholder="Title" disabled={!editingAllowed}/>
-            </Form.Item>     
-            <Form.Item {...formItemLayout} label="Description">
-                <Input id="job_desc" name="description" onChange={this.onChange} value={description} defaultValue={description} placeholder="Description" disabled={!editingAllowed}/>
-            </Form.Item>
-            {this.props.selectedJobType != 'Data Profile' ? 
-              <Form.Item {...formItemLayout} label="Git Repo">
-                  <Input id="job_gitRepo" name="gitrepo" onChange={this.onChange} value={gitrepo} defaultValue={gitrepo} placeholder="Git Repo" disabled={!editingAllowed}/>
-              </Form.Item>
-              : null }
-            <Form.Item {...formItemLayout} label="Entry BWR">
-                <Input id="job_entryBWR" name="entryBWR" onChange={this.onChange} value={entryBWR} defaultValue={entryBWR} placeholder="Primary Service" disabled={!editingAllowed}/>
-            </Form.Item>
-            <Row type="flex">
-              <Col span={12} order={1}>
-                <Form.Item {...threeColformItemLayout} label="Contact">
-                    <Input id="job_bkp_svc" name="contact" onChange={this.onChange} value={contact} defaultValue={contact} placeholder="Contact" disabled={!editingAllowed}/>
-                </Form.Item>
-              </Col>
-              <Col span={12} order={2}>  
-                <Form.Item {...threeColformItemLayout} label="Author">
-                    <Input id="job_author" name="author" onChange={this.onChange} value={author} defaultValue={author} placeholder="Author" disabled={!editingAllowed}/>
-                </Form.Item>
-              </Col>  
-            </Row>
-              
-            <Form.Item {...formItemLayout} label="Job Type">
-                <Select placeholder="Job Type" value={(jobType != '') ? jobType : ""} style={{ width: 190 }} onChange={this.onJobTypeChange} disabled={!editingAllowed}>
-                    {jobTypes.map(d => <Option key={d}>{d}</Option>)}
-              </Select>
-            </Form.Item>
-
-          </Form>
-
-          </TabPane>
-          <TabPane tab="Input Params" key="2">
-            <EditableTable 
-              columns={columns} 
-              dataSource={inputParams}                 
-              editingAllowed={editingAllowed}
-              dataDefinitions={this.state.dataDefinitions}
-              showDataDefinition={true}
-              setData={this.setInputParamsData}/>        
-          </TabPane>
-
-          <TabPane tab="Input Files" key="3">
-            <div>
-              <Form layout="inline">
-                <Form.Item label="Input Files">
-                  <Select id="inputfiles" placeholder="Select Input Files" defaultValue={this.state.selectedInputdFile} onChange={this.handleInputFileChange} style={{ width: 290 }} disabled={!editingAllowed}>
-                    {sourceFiles.map(d => <Option value={d.id} key={d.id}>{(d.title)?d.title:d.name}</Option>)}
+          <Tabs
+            defaultActiveKey="1"
+          >
+            <TabPane tab="Basic" key="1">
+              <Form layout="vertical">
+                {/*{this.props.isNewIndex ?*/}
+                <div>
+                <Form.Item {...formItemLayout} label="Cluster">
+                   <Select placeholder="Select a Cluster" onChange={this.onClusterSelection} style={{ width: 190 }} disabled={!editingAllowed}>
+                    {clusters.map(cluster => <Option key={cluster.id}>{cluster.name}</Option>)}
                   </Select>
                 </Form.Item>
-                <Form.Item>
-                    <Button type="primary" onClick={this.handleAddInputFile} disabled={!editingAllowed}>
-                        Add
-                    </Button>
+                <Form.Item {...formItemLayout} label="Job">
+                  <AutoComplete
+                    className="certain-category-search"
+                    dropdownClassName="certain-category-search-dropdown"
+                    dropdownMatchSelectWidth={false}
+                    dropdownStyle={{ width: 300 }}
+                    size="large"
+                    style={{ width: '100%' }}
+                    dataSource={jobSearchSuggestions}
+                    onChange={(value) => this.searchJobs(value)}
+                    onSelect={(value) => this.onJobSelected(value)}
+                    placeholder="Search jobs"
+                    optionLabelProp="text"
+                    disabled={!editingAllowed}
+                  >
+                    <Input id="autocomplete_field" suffix={this.state.autoCompleteSuffix} autoComplete="off"/>
+                  </AutoComplete>
+                </Form.Item>
+                </div>
+                  {/*: null
+                }*/}
+                <Form.Item {...formItemLayout} label="Name">
+                  <Input id="job_name" name="name" onChange={this.onChange} value={name} defaultValue={name} placeholder="Name" disabled={true} disabled={!editingAllowed}/>
+                </Form.Item>
+                <Form.Item {...formItemLayout} label="Title">
+                  <Input id="job_title" name="title" onChange={this.onChange} value={title} defaultValue={title} placeholder="Title" disabled={!editingAllowed}/>
+                </Form.Item>
+                <Form.Item {...formItemLayout} label="Description">
+                  <Input id="job_desc" name="description" onChange={this.onChange} value={description} defaultValue={description} placeholder="Description" disabled={!editingAllowed}/>
+                </Form.Item>
+                {this.props.selectedJobType != 'Data Profile' ?
+                  <Form.Item {...formItemLayout} label="Git Repo">
+                    <Input id="job_gitRepo" name="gitrepo" onChange={this.onChange} value={gitrepo} defaultValue={gitrepo} placeholder="Git Repo" disabled={!editingAllowed}/>
+                  </Form.Item>
+                : null }
+                <Form.Item {...formItemLayout} label="Entry BWR">
+                  <Input id="job_entryBWR" name="entryBWR" onChange={this.onChange} value={entryBWR} defaultValue={entryBWR} placeholder="Primary Service" disabled={!editingAllowed}/>
+                </Form.Item>
+                <Row type="flex">
+                  <Col span={12} order={1}>
+                    <Form.Item {...threeColformItemLayout} label="Contact">
+                        <Input id="job_bkp_svc" name="contact" onChange={this.onChange} value={contact} defaultValue={contact} placeholder="Contact" disabled={!editingAllowed}/>
+                    </Form.Item>
+                  </Col>
+                  <Col span={12} order={2}>
+                    <Form.Item {...threeColformItemLayout} label="Author">
+                        <Input id="job_author" name="author" onChange={this.onChange} value={author} defaultValue={author} placeholder="Author" disabled={!editingAllowed}/>
+                    </Form.Item>
+                  </Col>
+                </Row>
+                <Form.Item {...formItemLayout} label="Job Type">
+                  <Select placeholder="Job Type" value={(jobType != '') ? jobType : ""} style={{ width: 190 }} onChange={this.onJobTypeChange} disabled={!editingAllowed}>
+                      {jobTypes.map(d => <Option key={d}>{d}</Option>)}
+                  </Select>
                 </Form.Item>
               </Form>
-
-              <Table
-                columns={fileColumns}
-                rowKey={record => record.id}
-                dataSource={inputFiles}
-                pagination={{ pageSize: 10 }} scroll={{ y: 460 }}
-              />
-            </div>
-
             </TabPane>
-          <TabPane tab="Output Files" key="4">
-            <div>
 
-              <Form layout="inline">
-                <Form.Item label="Output Files">
-                  <Select id="outputfiles" placeholder="Select Output Files" defaultValue={this.state.selectedOutputFile} onChange={this.handleOutputFileChange} style={{ width: 290 }} disabled={!editingAllowed}>
-                    {sourceFiles.map(d => <Option value={d.id} key={d.id}>{(d.title)?d.title:d.name}</Option>)}
-                  </Select>
-                </Form.Item>
-                <Form.Item>
-                    <Button type="primary" disabled={!editingAllowed} onClick={this.handleAddOutputFile}>
-                        Add
-                    </Button>
+            <TabPane tab="ECL" key="2">
+              <Form layout="vertical">
+                <Form.Item {...eclItemLayout} label="ECL">
+                  <EclEditor id="job_ecl" name="ecl" onChange={this.onChange} targetDomId="jobEcl" value={ecl} disabled={true} />
                 </Form.Item>
               </Form>
+            </TabPane>
 
-              <Table
-                columns={fileColumns}
-                rowKey={record => record.id}
-                dataSource={outputFiles}
-                pagination={{ pageSize: 10 }} scroll={{ y: 460 }}
-              />
-             </div>
-          </TabPane>
+            <TabPane tab="Input Params" key="3">
+              <EditableTable
+                columns={columns}
+                dataSource={inputParams}
+                editingAllowed={editingAllowed}
+                dataDefinitions={this.state.dataDefinitions}
+                showDataDefinition={true}
+                setData={this.setInputParamsData}/>
+            </TabPane>
 
-          {!this.props.isNew ? 
+            <TabPane tab="Input Files" key="4">
+              <div>
+                <Form layout="inline">
+                  <Form.Item label="Input Files">
+                    <Select id="inputfiles" placeholder="Select Input Files" defaultValue={this.state.selectedInputdFile} onChange={this.handleInputFileChange} style={{ width: 290 }} disabled={!editingAllowed}>
+                      {sourceFiles.map(d => <Option value={d.id} key={d.id}>{(d.title)?d.title:d.name}</Option>)}
+                    </Select>
+                  </Form.Item>
+                  <Form.Item>
+                    <Button type="primary" onClick={this.handleAddInputFile} disabled={!editingAllowed}>
+                      Add
+                    </Button>
+                  </Form.Item>
+                </Form>
+
+                <Table
+                  columns={fileColumns}
+                  rowKey={record => record.id}
+                  dataSource={inputFiles}
+                  pagination={{ pageSize: 10 }} scroll={{ y: 460 }}
+                />
+              </div>
+            </TabPane>
+
+            <TabPane tab="Output Files" key="5">
+              <div>
+                <Form layout="inline">
+                  <Form.Item label="Output Files">
+                    <Select id="outputfiles" placeholder="Select Output Files" defaultValue={this.state.selectedOutputFile} onChange={this.handleOutputFileChange} style={{ width: 290 }} disabled={!editingAllowed}>
+                      {sourceFiles.map(d => <Option value={d.id} key={d.id}>{(d.title)?d.title:d.name}</Option>)}
+                    </Select>
+                  </Form.Item>
+                  <Form.Item>
+                    <Button type="primary" disabled={!editingAllowed} onClick={this.handleAddOutputFile}>
+                      Add
+                    </Button>
+                  </Form.Item>
+                </Form>
+                <Table
+                  columns={fileColumns}
+                  rowKey={record => record.id}
+                  dataSource={outputFiles}
+                  pagination={{ pageSize: 10 }} scroll={{ y: 460 }}
+                />
+              </div>
+            </TabPane>
+
+            {!this.props.isNew ?
             <TabPane tab="Dataflows" key="7">
               <AssociatedDataflows assetName={name} assetType={'Job'}/>
             </TabPane> : null}
-        </Tabs>
+          </Tabs>
         </Modal>
       </div>
     );
@@ -720,4 +733,3 @@ class JobDetails extends Component {
 }
 const JobDetailsForm = Form.create()(JobDetails);
 export default JobDetailsForm;
-

--- a/client-reactjs/src/components/common/EclEditor.js
+++ b/client-reactjs/src/components/common/EclEditor.js
@@ -1,0 +1,47 @@
+import React, { Component, Fragment } from 'react';
+import { debounce } from 'lodash';
+import { ECLEditor as eclCodemirror } from '@hpcc-js/codemirror';
+
+class EclEditor extends Component {
+
+  eclEditor = null;
+
+  constructor(props) {
+    super(props);
+    this.state = { ecl: '' };
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.value != prevProps.value) {
+      this.name = this.props.name;
+      this.value = this.props.value;
+      this.eclEditor.ecl(this.props.value);
+    }
+  }
+
+  componentDidMount() {
+    this.setState((state, props) => {
+      return { ecl: props.value }
+    });
+    this.eclEditor = new eclCodemirror()
+      .target(this.props.targetDomId)
+      .readOnly(this.props.disabled)
+      .render();
+
+    this.eclEditor._codemirror.doc.on('change', debounce(() => {
+      this.value = this.eclEditor.ecl();
+      this.props.onChange({ target: this });
+    }, 500));
+  }
+
+  render() {
+    return (
+      <Fragment>
+        <div id={this.props.targetDomId}></div>
+      </Fragment>
+    );
+  }
+
+}
+
+export { EclEditor };

--- a/server/migrations/20201109194304-job_add_ecl.js
+++ b/server/migrations/20201109194304-job_add_ecl.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Job', 'ecl', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+        after: 'description'
+      }
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Job', 'ecl');
+  }
+};

--- a/server/models/job.js
+++ b/server/models/job.js
@@ -12,6 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     author: DataTypes.STRING,
     contact: DataTypes.STRING,
     description: DataTypes.STRING,
+    ecl: DataTypes.TEXT,
     entryBWR: DataTypes.STRING,
     gitRepo: DataTypes.STRING,
     jobType: DataTypes.STRING,

--- a/server/routes/hpcc/read.js
+++ b/server/routes/hpcc/read.js
@@ -177,11 +177,11 @@ router.get('/getCluster', function (req, res) {
 router.post('/newcluster', [
 
   body('thor_host').isURL({'require_protocol':true, 'require_host':true }).withMessage("Invalid thor host"),
-  body('roxie_host').isURL({'require_protocol':true, 'require_host':true }).withMessage("Invalid roxie host"),	
+  body('roxie_host').isURL({'require_protocol':true, 'require_host':true }).withMessage("Invalid roxie host"),
   body('thor_port')
-    .isInt().withMessage('Invalid thor port'),  
+    .isInt().withMessage('Invalid thor port'),
   body('roxie_port')
-    .isInt().withMessage('Invalid roxie port')      
+    .isInt().withMessage('Invalid roxie port')
 	], async function (req, res) {
 		const errors = validationResult(req).formatWith(validatorUtil.errorFormatter);
     if (!errors.isEmpty()) {
@@ -245,10 +245,10 @@ router.get('/getFileInfo', [
   }
 	console.log('fileName: '+req.query.fileName+ " clusterId: "+req.query.clusterid );
 	hpccUtil.fileInfo(req.query.fileName, req.query.clusterid).then((fileInfo) => {
-		res.json(fileInfo);	
+		res.json(fileInfo);
 	}).catch((err) => {
-		console.log('err', err);	
-	})		
+		console.log('err', err);
+	})
 });
 
 
@@ -317,7 +317,7 @@ function getIndexColumns(cluster, indexName) {
   	});
 }
 
-router.get('/getData', [  
+router.get('/getData', [
   query('clusterid')
     .isUUID(4).withMessage('Invalid cluster id'),
   query('fileName')
@@ -429,7 +429,7 @@ router.get('/getFileProfileHTML', function (req, res) {
     }
 });
 
-router.get('/getQueryInfo', [  
+router.get('/getQueryInfo', [
   query('clusterid')
     .isUUID(4).withMessage('Invalid cluster id'),
   query('queryName')
@@ -458,7 +458,7 @@ router.get('/getQueryInfo', [
 						response[firstKey].forEach((responseParam, idx) => {
 							responseObj.push(
 							{
-								"id": idx, 
+								"id": idx,
 								"name" : responseParam.id,
     						"type" : responseParam.type
 							});
@@ -480,7 +480,7 @@ router.get('/getQueryInfo', [
   }
 });
 
-router.get('/getJobInfo', [  
+router.get('/getJobInfo', [
   query('clusterid')
     .isUUID(4).withMessage('Invalid cluster id'),
   query('jobWuid')
@@ -511,25 +511,26 @@ router.get('/getJobInfo', [
 						let clusterAuth = hpccUtil.getClusterAuth(cluster);
       			let wuService = new hpccJSComms.WorkunitsService({ baseUrl: cluster.thor_host + ':' + cluster.thor_port, userID:(clusterAuth ? clusterAuth.user : ""), password:(clusterAuth ? clusterAuth.password : "")});
 						wuService.WUListQueries({"WUID":req.query.jobWuid}).then(response => {
-							if(response.QuerysetQueries && response.QuerysetQueries.QuerySetQuery && response.QuerysetQueries.QuerySetQuery.length > 0) { 
+							if(response.QuerysetQueries && response.QuerysetQueries.QuerySetQuery && response.QuerysetQueries.QuerySetQuery.length > 0) {
 								wuService.WUQueryDetails({"QueryId":response.QuerysetQueries.QuerySetQuery[0].Id, "QuerySet":"roxie"}).then(queryDetails => {
 									queryDetails.LogicalFiles.Item.forEach((logicalFile)	=> {
 										sourceFiles.push({"name":logicalFile})
 									})
 									res.json({
-				      			"sourceFiles": sourceFiles,
-				      			"outputFiles": [],
-				      			"Jobname": result.WUInfoResponse.Workunit.Jobname,
-				      			"description": result.WUInfoResponse.Workunit.Description,
-				      			"entryBWR": result.WUInfoResponse.Workunit.Jobname
-				      		});	
+                    "sourceFiles": sourceFiles,
+                    "outputFiles": [],
+                    "Jobname": result.WUInfoResponse.Workunit.Jobname,
+                    "description": result.WUInfoResponse.Workunit.Description,
+                    "ecl": result.WUInfoResponse.Workunit.Query.Text,
+                    "entryBWR": result.WUInfoResponse.Workunit.Jobname
+				      		});
 								})
 							} else {
 								res.json([]);
 							}
 						});
 	      	} else {
-		      	if(result.WUInfoResponse && result.WUInfoResponse.Workunit) {		      			
+		      	if(result.WUInfoResponse && result.WUInfoResponse.Workunit) {
 		      		var wuInfoResponse = result.WUInfoResponse.Workunit, fileInfo = {};
 		      		if(wuInfoResponse.SourceFiles && wuInfoResponse.SourceFiles.ECLSourceFile) {
 		      			wuInfoResponse.SourceFiles.ECLSourceFile.forEach((sourceFile) => {
@@ -547,15 +548,16 @@ router.get('/getJobInfo', [
 		      		}
 
 		      		res.json({
-		      			"sourceFiles": sourceFiles,
-		      			"outputFiles": outputFiles,
-		      			"Jobname": result.WUInfoResponse.Workunit.Jobname,
-		      			"description": result.WUInfoResponse.Workunit.Description,
-		      			"entryBWR": result.WUInfoResponse.Workunit.Jobname
+                "sourceFiles": sourceFiles,
+                "outputFiles": outputFiles,
+                "Jobname": result.WUInfoResponse.Workunit.Jobname,
+                "description": result.WUInfoResponse.Workunit.Description,
+                "ecl": result.WUInfoResponse.Workunit.Query.Text,
+                "entryBWR": result.WUInfoResponse.Workunit.Jobname
 		      		});
 						}
-	      		
-	      	}	
+
+	      	}
 	      }
 
       	});

--- a/server/routes/job/read.js
+++ b/server/routes/job/read.js
@@ -50,14 +50,14 @@ let updateDataFlowGraph = (applicationId, dataflowId, nodes, edges) => {
         dataflowId: dataflowId
       }, {where:{application_id:applicationId, dataflowId:dataflowId}}).then((dataflowGraphUpdate) => {
         resolve({'nodes':currentNodes, 'edges':currentEdges});
-      })          
+      })
     }).catch((err) => {
       reject(err);
     })
   });
 }
 
-router.post('/saveJob', [  
+router.post('/saveJob', [
   body('_id')
   .optional({checkFalsy:true})
     .isUUID(4).withMessage('Invalid id'),
@@ -84,6 +84,7 @@ router.post('/saveJob', [
           author: req.body.basic.author,
           contact: req.body.basic.contact,
           description: req.body.basic.description,
+          ecl: req.body.basic.ecl,
           entryBWR: req.body.basic.entryBWR,
           gitRepo: req.body.basic.gitRepo,
           jobType: req.body.basic.jobType,
@@ -102,7 +103,7 @@ router.post('/saveJob', [
       JobParam.destroy({where:{application_id:applicationId, job_id: jobId}}).then((deleted) => {
         return JobParam.bulkCreate(
           jobParamsToSave
-        )        
+        )
       })
     }).then(function(jobParam) {
         if(req.body.autoCreateFiles) {
@@ -152,9 +153,9 @@ router.post('/saveJob', [
                     edges.push(edge);
 
                     fieldsToUpdate = {"file_id": newFile.id, "application_id" : applicationId};
-                    let fileLayoutToSave = hpccUtil.updateCommonData(fileInfo.layout, fieldsToUpdate);                            
+                    let fileLayoutToSave = hpccUtil.updateCommonData(fileInfo.layout, fieldsToUpdate);
                     return FileLayout.bulkCreate(fileLayoutToSave, {updateOnDuplicate: ["name", "type", "displayType", "displaySize", "textJustification", "format","data_types", "isPCI", "isPII", "isHIPAA", "description", "required"]});
-                 }).then((fileLayout) => {   
+                 }).then((fileLayout) => {
                     let fileValidationsToSave = hpccUtil.updateCommonData(fileInfo.validations, fieldsToUpdate);
                     return FileValidation.bulkCreate(
                       fileValidationsToSave,
@@ -172,11 +173,11 @@ router.post('/saveJob', [
             })
             console.log('resolving....');
             Promise.all(promises).then(() => {
-              console.log("job and files created....")   
-              
+              console.log("job and files created....")
+
               updateDataFlowGraph(req.body.basic.applicationId, req.body.basic.dataflowId, nodes, edges).then((dataflowGraph) => {
-                resolve(dataflowGraph)           
-              });          
+                resolve(dataflowGraph)
+              });
             });
           }).then((results) => {
             console.log('results: '+JSON.stringify(results));
@@ -193,7 +194,7 @@ router.post('/saveJob', [
   }
 });
 
-router.get('/job_list', [    
+router.get('/job_list', [
   query('app_id')
     .isUUID(4).withMessage('Invalid application id'),
 ], (req, res) => {
@@ -215,11 +216,11 @@ router.get('/job_list', [
 });
 
 
-router.get('/job_details', [    
+router.get('/job_details', [
   query('app_id')
     .isUUID(4).withMessage('Invalid application id'),
   query('job_id')
-    .isUUID(4).withMessage('Invalid job id'),  
+    .isUUID(4).withMessage('Invalid job id'),
 ], (req, res) => {
   const errors = validationResult(req).formatWith(validatorUtil.errorFormatter);
   if (!errors.isEmpty()) {
@@ -254,11 +255,11 @@ router.get('/job_details', [
   }
 });
 
-router.post('/delete', [    
+router.post('/delete', [
   body('application_id')
     .isUUID(4).withMessage('Invalid application id'),
   body('jobId')
-    .isUUID(4).withMessage('Invalid job id'),  
+    .isUUID(4).withMessage('Invalid job id'),
 ], (req, res) => {
   const errors = validationResult(req).formatWith(validatorUtil.errorFormatter);
   if (!errors.isEmpty()) {


### PR DESCRIPTION
closes #146 

commits were squashed, separate messages are below:
* code style
* add EclEditor component
* add new tab to JobDetails modal for ECL
* code style
* add "ecl" property to JSON returned in GET /hpcc/read/getJobInfo
* fix content function, should call .ecl() not .markdown()
* add migration for "ecl" column to "jobs" schema / model
* add "ecl" paramater to the object passed to the Job model update() in POST /job/saveJob
* functional change is on line 87, but there were also a lot of training whitespace removed by editorconfig rules
* use state to update value in ECLEditor component
* add ECLEditor to new tab in JobDetails modal