### PR TITLE
Markdown for description fields

### DIFF
--- a/client-reactjs/package-lock.json
+++ b/client-reactjs/package-lock.json
@@ -2104,6 +2104,14 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
     },
+    "@types/mdast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
+      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2257,6 +2265,11 @@
           }
         }
       }
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/yargs": {
       "version": "13.0.10",
@@ -3466,6 +3479,11 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
+    "bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -4083,6 +4101,21 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -8517,6 +8550,63 @@
         }
       }
     },
+    "html-to-react": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.5.tgz",
+      "integrity": "sha512-KONZUDFPg5OodWaQu2ymfkDmU0JA7zB1iPfvyHehTmMUZnk0DS7/TyCMTzsLH6b4BvxX15g88qZCXFhJWktsmA==",
+      "requires": {
+        "domhandler": "^3.3.0",
+        "htmlparser2": "^5.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.27.1"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
+          "integrity": "sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
+        },
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "domutils": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
+          "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
+          "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.3.0",
+            "domutils": "^2.4.2",
+            "entities": "^2.0.0"
+          }
+        }
+      }
+    },
     "html-webpack-plugin": {
       "version": "4.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz",
@@ -8954,6 +9044,20 @@
         }
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
@@ -9041,6 +9145,11 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
+    "is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -9110,6 +9219,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-iexplorer": {
       "version": "1.0.0",
@@ -10215,6 +10329,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -10458,6 +10577,30 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdast-add-list-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
+      "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
+      "requires": {
+        "unist-util-visit-parents": "1.1.2"
+      }
+    },
+    "mdast-util-from-markdown": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.1.tgz",
+      "integrity": "sha512-qJXNcFcuCSPqUF0Tb0uYcFDIq67qwB3sxo9RPdf9vG8T90ViKnksFqdB/Coq2a7sTnxL/Ify2y7aIQXDkQFH0w==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^1.0.0",
+        "micromark": "~2.10.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
+      "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
+    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -10550,6 +10693,30 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
       "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g=="
+    },
+    "micromark": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.10.1.tgz",
+      "integrity": "sha512-fUuVF8sC1X7wsCS29SYQ2ZfIZYbTymp0EYr6sab3idFjigFFjGa5UwoniPlV9tAgntjuapW1t9U+S0yDYeGKHQ==",
+      "requires": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "micromatch": {
       "version": "3.1.10",
@@ -11718,6 +11885,19 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-json": {
@@ -13255,6 +13435,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -14060,6 +14245,23 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-markdown": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
+      "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
+      "requires": {
+        "@types/mdast": "^3.0.3",
+        "@types/unist": "^2.0.3",
+        "html-to-react": "^1.3.4",
+        "mdast-add-list-metadata": "1.0.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "remark-parse": "^9.0.0",
+        "unified": "^9.0.0",
+        "unist-util-visit": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
     "react-plotly.js": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.5.0.tgz",
@@ -14474,6 +14676,14 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
+    "remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "requires": {
+        "mdast-util-from-markdown": "^0.8.0"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -14540,6 +14750,11 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
       "version": "2.88.2",
@@ -16660,6 +16875,11 @@
         "cdt2d": "^1.0.0"
       }
     },
+    "trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+    },
     "ts-pnp": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
@@ -16791,6 +17011,31 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
     },
+    "unified": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.0.tgz",
+      "integrity": "sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==",
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
+    },
     "union-find": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
@@ -16832,6 +17077,45 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "unist-util-is": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.3.tgz",
+      "integrity": "sha512-bTofCFVx0iQM8Jqb1TBDVRIQW03YkD3p66JOd/aCWuqzlLyUtx1ZAGw/u+Zw+SttKvSVcvTiKYbfrtLoLefykw=="
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "dependencies": {
+        "unist-util-visit-parents": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+          "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0"
+          }
+        }
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
+      "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -17163,6 +17447,34 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vfile": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.0.tgz",
+      "integrity": "sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        }
+      }
+    },
+    "vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vm-browserify": {

--- a/client-reactjs/package.json
+++ b/client-reactjs/package.json
@@ -23,6 +23,7 @@
     "plotly.js-basic-dist": "^1.54.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-markdown": "^5.0.3",
     "react-plotly.js": "^2.5.0",
     "react-redux": "^7.2.1",
     "react-router": "^5.2.0",

--- a/client-reactjs/src/components/admin/Applications.js
+++ b/client-reactjs/src/components/admin/Applications.js
@@ -5,7 +5,9 @@ import { authHeader, handleError } from "../common/AuthHeader.js";
 import { hasAdminRole } from "../common/AuthUtil.js";
 import { connect } from 'react-redux';
 import { Constants } from '../common/Constants';
+import { MarkdownEditor } from "../common/MarkdownEditor.js";
 import ShareApp from "./ShareApp";
+import ReactMarkdown from 'react-markdown';
 import { applicationActions } from '../../redux/actions/Application';
 
 class Applications extends Component {
@@ -178,7 +180,11 @@ class Applications extends Component {
       if (err !== null) {
         return;
       }
-      if(this.state.applications.filter(application => application.title == this.state.newApp.title).length > 0) {
+      if(this.state.applications.filter(application => {
+        if (application.id != this.state.newApp.id && application.title == this.state.newApp.title) {
+          return application;
+        }
+      }).length > 0) {
         message.config({top:150})
         message.error("There is already an application with the same name. Please select a different name.")
         return;
@@ -255,7 +261,10 @@ class Applications extends Component {
     }, {
       width: '20%',
       title: 'Description',
-      dataIndex: 'description'
+      dataIndex: 'description',
+      className: 'overflow-hidden',
+      ellipsis: true,
+      render: (text, record) => <ReactMarkdown children={text} />
     }, {
       width: '10%',
       title: 'Created By',
@@ -294,7 +303,7 @@ class Applications extends Component {
       },
       wrapperCol: {
         xs: { span: 2 },
-        sm: { span: 10 },
+        sm: { span: 18 },
       },
     };
 
@@ -337,14 +346,7 @@ class Applications extends Component {
             </Form.Item>
 
             <Form.Item {...formItemLayout} label="Description">
-              {getFieldDecorator('description', {
-                rules: [{
-                  pattern: new RegExp(/^[a-zA-Z]{1}[a-zA-Z0-9_.\-]*$/),
-                  message: 'Invalid description!'
-                }],
-              })(
-                <Input id="app_description" name="description" onChange={this.onChange} placeholder="Description" value={this.state.newApp.description}/>
-              )}
+              <MarkdownEditor id="app_description" name="description" onChange={this.onChange} targetDomId="AppDescr" value={this.state.newApp.description}/>
             </Form.Item>
           </Form>
         </Modal>

--- a/client-reactjs/src/components/application/DataDictionary/DataDictionaryTable.js
+++ b/client-reactjs/src/components/application/DataDictionary/DataDictionaryTable.js
@@ -6,6 +6,7 @@ import useFileDetailsForm from '../../../hooks/useFileDetailsForm';
 import { Constants } from '../../common/Constants';
 import { useSelector } from "react-redux";
 import DataDefinitionDetailsDialog from './DataDefinitionDetailsDialog';
+import ReactMarkdown from 'react-markdown';
 
 function DataDictionaryTable({dataDefinitions, applicationId, onDataUpdated, closeAddDlg}) {
   const [data, setData] = useState([]);
@@ -16,22 +17,22 @@ function DataDictionaryTable({dataDefinitions, applicationId, onDataUpdated, clo
 
   const authReducer = useSelector(state => state.authenticationReducer);
 
-  useEffect(() => {    
+  useEffect(() => {
     setData(dataDefinitions);
   }, [dataDefinitions])
 
   const handleEditDataDictionary = (selectedDataDefinition) => {
     setSelectedDataDefinition(selectedDataDefinition);
-    if(selectedDataDefinition.type != 'file') {      
+    if(selectedDataDefinition.type != 'file') {
       setShowDetailsDialog(true);
     } else {
       console.log('setShowFileDetailsDialog: '+setShowFileDetailsDialog)
       toggle();
       setShowFileDetailsDialog(true);
     }
-    
+
   }
-  
+
   const handleDataDictionaryDelete = (record) => {
     if(record.type != 'file') {
       fetch('/api/data-dictionary/delete', {
@@ -55,7 +56,7 @@ function DataDictionaryTable({dataDefinitions, applicationId, onDataUpdated, clo
     } else {
       handleFileDelete(record.id);
     }
-  }  
+  }
 
   const handleFileDelete = (fileId) => {
     var data = JSON.stringify({fileId: fileId, application_id: applicationId});
@@ -108,7 +109,10 @@ function DataDictionaryTable({dataDefinitions, applicationId, onDataUpdated, clo
   {
     title: 'Description',
     dataIndex: 'description',
+    className: 'overflow-hidden',
+    ellipsis: true,
     width: '30%',
+    render: (text, record) => <ReactMarkdown children={text} />
   },
   {
     title: 'Created',
@@ -116,14 +120,14 @@ function DataDictionaryTable({dataDefinitions, applicationId, onDataUpdated, clo
     width: '30%',
     render: (text, record) => {
       let createdAt = new Date(text);
-      return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US') 
+      return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US')
     }
   },
   {
     width: '20%',
     title: 'Action',
     dataIndex: '',
-    className: editingAllowed ? "show-column" : "hide-column",    
+    className: editingAllowed ? "show-column" : "hide-column",
     render: (text, record) =>
       <span>
         <a href="#" onClick={(row) => handleEditDataDictionary(record)}><Tooltip placement="right" title={"Edit Dataflow"}><Icon type="edit" /></Tooltip></a>
@@ -135,11 +139,11 @@ function DataDictionaryTable({dataDefinitions, applicationId, onDataUpdated, clo
   }];
 	return (
 	  <React.Fragment>
-	   <Table        
+	   <Table
         columns={dataDefnCols}
         rowKey={record => record.id}
-        dataSource={data}        
-        pagination={{ pageSize: 20 }} 
+        dataSource={data}
+        pagination={{ pageSize: 20 }}
         scroll={{ y: '70vh' }}
       />
       {showDetailsDialog ? <DataDefinitionDetailsDialog selectedDataDefinition={selectedDataDefinition} applicationId={applicationId} onDataUpdated={onDataUpdated} closeDialog={closeDialog}/> : null}
@@ -155,7 +159,7 @@ function DataDictionaryTable({dataDefinitions, applicationId, onDataUpdated, clo
           "onClose": closeFileDialog,
           "user": authReducer.user}) : null}
      </React.Fragment>
-	  )  
+	  )
 
 }
 

--- a/client-reactjs/src/components/application/Dataflow/AddDataflow.js
+++ b/client-reactjs/src/components/application/Dataflow/AddDataflow.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom';
 import { Button, Form, Input, message, Popconfirm, Icon, Tooltip, Modal, Select } from 'antd/lib';
-import { authHeader, handleError } from "../../common/AuthHeader.js"
+import { authHeader, handleError } from "../../common/AuthHeader.js";
+import { MarkdownEditor } from "../../common/MarkdownEditor.js";
 const Option = Select.Option;
 
 function AddDataflow({isShowing, toggle, applicationId, onDataFlowUpdated, selectedDataflow}) {
@@ -15,12 +16,12 @@ function AddDataflow({isShowing, toggle, applicationId, onDataFlowUpdated, selec
   const [form, setForm] = useState({
     submitted: false,
     confirmLoading: false
-  }); 
+  });
 
   const [whitelistedClusters, setWhitelistedClusters] = useState([]);
 
   const [clusterSelected, setClusterSelected] = useState('');
-  
+
   useEffect(() => {
     setDataFlow({...selectedDataflow});
     setClusterSelected(selectedDataflow ? selectedDataflow.clusterId : '')
@@ -37,7 +38,7 @@ function AddDataflow({isShowing, toggle, applicationId, onDataFlowUpdated, selec
     },
     wrapperCol: {
       xs: { span: 2 },
-      sm: { span: 10 },
+      sm: { span: 18 },
     },
   };
 
@@ -59,29 +60,29 @@ function AddDataflow({isShowing, toggle, applicationId, onDataFlowUpdated, selec
     });
   }
 
-  const onClusterSelection= (value) => {  
+  const onClusterSelection= (value) => {
     setClusterSelected(value);
   }
 
-  const handleAddAppOk = () => {    
+  const handleAddAppOk = () => {
     setForm({
       submitted: true
     });
-    
+
     if(dataFlow.title == '' || clusterSelected == '') {
       return false;
     }
     setForm({
-      confirmLoading: true,  
+      confirmLoading: true,
       submitted: true
-    });    
+    });
 
     fetch('/api/dataflow/save', {
       method: 'post',
       headers: authHeader(),
       body: JSON.stringify(
       	{	"id": dataFlow.id,
-      		"application_id": applicationId, 
+      		"application_id": applicationId,
       		"title": dataFlow.title,
       		"description": dataFlow.description,
           "clusterId": clusterSelected
@@ -91,7 +92,7 @@ function AddDataflow({isShowing, toggle, applicationId, onDataFlowUpdated, selec
         return response.json();
       }
       handleError(response);
-    }).then(function(data) {           
+    }).then(function(data) {
       setForm({
 	      confirmLoading: false,
 	      submitted: false
@@ -141,17 +142,17 @@ function AddDataflow({isShowing, toggle, applicationId, onDataFlowUpdated, selec
           visible={isShowing}
           confirmLoading={form.confirmLoading}
         >
-	        <Form layout="vertical">	            
+	        <Form layout="vertical">
 	            <div className={'form-group' + (form.submitted && !dataFlow.title ? ' has-error' : '')}>
 		            <Form.Item {...formItemLayout} label="Title">
 							    <Input id="title" name="title" onChange={e => setDataFlow({...dataFlow, [e.target.name]: e.target.value})} placeholder="Title" value={dataFlow.title}/>
-			            {(form.submitted && !dataFlow.title || splCharacters.test(dataFlow.title)) && 
+			            {(form.submitted && !dataFlow.title || splCharacters.test(dataFlow.title)) &&
 		                    <div className="error">Please enter a valid Title</div>
 			            }
 		            </Form.Item>
 	            </div>
 	            <Form.Item {...formItemLayout} label="Description">
-				    		<Input id="description" name="description" onChange={e => setDataFlow({...dataFlow, [e.target.name]: e.target.value})} placeholder="Description" value={dataFlow.description}/>
+				    		<MarkdownEditor id="description" name="description" targetDomId="dataflowDescr" onChange={e => setDataFlow({...dataFlow, [e.target.name]: e.target.value})} value={dataFlow.description}/>
 	            </Form.Item>
               <Form.Item {...formItemLayout} label="Cluster">
                 <Select placeholder="Select a Cluster" onChange={onClusterSelection} style={{ width: 290 }} value={clusterSelected}>
@@ -165,7 +166,7 @@ function AddDataflow({isShowing, toggle, applicationId, onDataFlowUpdated, selec
         </Modal>
      </div>
      </React.Fragment>
-	  )  
+	  )
 
 }
 

--- a/client-reactjs/src/components/application/Dataflow/DataflowTable.js
+++ b/client-reactjs/src/components/application/Dataflow/DataflowTable.js
@@ -4,12 +4,13 @@ import { authHeader, handleError } from "../../common/AuthHeader.js"
 import { hasEditPermission } from "../../common/AuthUtil.js";
 import { Constants } from '../../common/Constants';
 import { useSelector } from "react-redux";
+import ReactMarkdown from 'react-markdown';
 
 function DataflowTable({data, applicationId, onSelectDataflow, onDataFlowUpdated, onDataFlowEdit}) {
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
-  
 
-  useEffect(() => {    
+
+  useEffect(() => {
     if(data && data.length > 0) {
       setSelectedRowKeys([data[0].id]);
       //onSelectDataflow(data[0]);
@@ -66,7 +67,10 @@ function DataflowTable({data, applicationId, onSelectDataflow, onDataFlowUpdated
   {
     title: 'Description',
     dataIndex: 'description',
+    className: 'overflow-hidden',
+    ellipsis: true,
     width: '30%',
+    render: (text, record) => <ReactMarkdown children={text} />
   },
   {
     title: 'Process Type',
@@ -79,14 +83,14 @@ function DataflowTable({data, applicationId, onSelectDataflow, onDataFlowUpdated
     width: '30%',
     render: (text, record) => {
       let createdAt = new Date(text);
-      return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US') 
+      return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US')
     }
   },
   {
     width: '20%',
     title: 'Action',
     dataIndex: '',
-    className: editingAllowed ? "show-column" : "hide-column",    
+    className: editingAllowed ? "show-column" : "hide-column",
     render: (text, record) =>
       <span>
         <a href="#" onClick={(row) => handleEditDataflow(record)}><Tooltip placement="right" title={"Edit Dataflow"}><Icon type="edit" /></Tooltip></a>
@@ -98,15 +102,15 @@ function DataflowTable({data, applicationId, onSelectDataflow, onDataFlowUpdated
   }];
 	return (
 	  <React.Fragment>
-	   <Table        
+	   <Table
         columns={dataflowCols}
         rowKey={record => record.id}
-        dataSource={data}        
+        dataSource={data}
         pagination={{ pageSize: 5 }} scroll={{ y: 380 }}
       />
 
      </React.Fragment>
-	  )  
+	  )
 
 }
 

--- a/client-reactjs/src/components/application/FileTable.js
+++ b/client-reactjs/src/components/application/FileTable.js
@@ -9,6 +9,7 @@ import { Constants } from '../common/Constants';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { assetsActions } from '../../redux/actions/Assets';
+import ReactMarkdown from 'react-markdown';
 
 class FileTable extends Component {
   state = {
@@ -178,9 +179,12 @@ class FileTable extends Component {
       render: (text, record) => <a href='#' onClick={(row) => this.handleEdit(record.id)}>{text}</a>
     },
     {
-        width: '20%',
-        title: 'Description',
-        dataIndex: 'description'
+      width: '20%',
+      title: 'Description',
+      dataIndex: 'description',
+      className: 'overflow-hidden',
+      ellipsis: true,
+      render: (text, record) => <ReactMarkdown children={text} />
     },
     {
         width: '10%',

--- a/client-reactjs/src/components/application/IndexTree.js
+++ b/client-reactjs/src/components/application/IndexTree.js
@@ -5,6 +5,7 @@ import React, { Component } from "react";
 import IndexDetailsForm from "./IndexDetails";
 import { authHeader, handleError } from "../common/AuthHeader.js"
 import { Constants } from '../common/Constants';
+import ReactMarkdown from 'react-markdown';
 
 class IndexTree extends Component {
   constructor(props) {
@@ -106,7 +107,10 @@ class IndexTree extends Component {
     {
       title: 'Description',
       dataIndex: 'description',
+      className: 'overflow-hidden',
+      ellipsis: true,
       width: '20%',
+      render: (text, record) => <ReactMarkdown children={text} />
     },
     {
       width: '10%',
@@ -119,14 +123,14 @@ class IndexTree extends Component {
       render: (text, record) => {
         return (record.dataflow && record.dataflow.title != '') ? record.dataflow.title : '';
       }
-    },        
+    },
     {
       width: '25%',
       title: 'Created',
       dataIndex: 'createdAt',
       render: (text, record) => {
         let createdAt = new Date(text);
-        return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US') 
+        return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US')
       }
     },
     {
@@ -148,7 +152,7 @@ class IndexTree extends Component {
             columns={indexColumns}
             rowKey={record => record.id}
             dataSource={this.state.indexes}
-            pagination={{ pageSize: 10 }} 
+            pagination={{ pageSize: 10 }}
             scroll={{ y: '70vh' }}
           />
         {this.state.openFileDetailsDialog ?

--- a/client-reactjs/src/components/application/JobList.js
+++ b/client-reactjs/src/components/application/JobList.js
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import { authHeader, handleError } from "../common/AuthHeader.js"
 import {handleJobDelete} from "../common/WorkflowUtil";
 import { Constants } from '../common/Constants';
+import ReactMarkdown from 'react-markdown';
 
 class JobList extends Component {
 
@@ -49,7 +50,7 @@ class JobList extends Component {
 
   componentDidMount() {
     if(this.state.applicationId != '') {
-      this.fetchDataAndRenderTable();      
+      this.fetchDataAndRenderTable();
     }
   }
 
@@ -106,11 +107,11 @@ class JobList extends Component {
     }, 200);
   }
 
-  handleDelete(id, objType) {    
+  handleDelete(id, objType) {
     console.log(id)
     this.handleJobDelete(id);
   }
-    
+
 
   handleJobDelete(jobId) {
     handleJobDelete(jobId, this.state.applicationId)
@@ -152,7 +153,10 @@ class JobList extends Component {
       {
         title: 'Description',
         dataIndex: 'description',
+        className: 'overflow-hidden',
+        ellipsis: true,
         width: '20%',
+        render: (text, record) => <ReactMarkdown children={text} />
       },
       {
         title: 'Type',
@@ -165,14 +169,14 @@ class JobList extends Component {
         render: (text, record) => {
           return (record.dataflow && record.dataflow.title != '') ? record.dataflow.title : '';
         }
-      },          
+      },
       {
         width: '25%',
         title: 'Created',
         dataIndex: 'createdAt',
         render: (text, record) => {
           let createdAt = new Date(text);
-          return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US') 
+          return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US')
         }
       },
       {
@@ -189,7 +193,7 @@ class JobList extends Component {
           </span>
       }];
 
-      
+
     return (
       <div>
         <div className="d-flex justify-content-end" style={{paddingTop:"55px", margin: "5px"}}>
@@ -205,11 +209,11 @@ class JobList extends Component {
               columns={jobColumns}
               rowKey={record => record.id}
               dataSource={this.state.assets}
-              pagination={{ pageSize: 10 }} 
+              pagination={{ pageSize: 10 }}
               scroll={{ y: '70vh' }}
             />
 
-          
+
           {this.state.openJobDetailsDialog ?
             <JobDetailsForm
               onRef={ref => (this.child = ref)}
@@ -219,8 +223,8 @@ class JobList extends Component {
               onRefresh={this.handleRefresh}
               onClose={this.closeJobDlg}
               user={this.props.user}/> : null}
-          
-        </div>        
+
+        </div>
       </div>
   )
   }

--- a/client-reactjs/src/components/application/QueryTable.js
+++ b/client-reactjs/src/components/application/QueryTable.js
@@ -6,6 +6,7 @@ import QueryDetailsForm from "./QueryDetails";
 import { authHeader, handleError } from "../common/AuthHeader.js"
 import { hasEditPermission } from "../common/AuthUtil.js";
 import { Constants } from '../common/Constants';
+import ReactMarkdown from 'react-markdown';
 
 class QueryTable extends Component {
   constructor(props) {
@@ -109,7 +110,10 @@ class QueryTable extends Component {
     {
       title: 'Description',
       dataIndex: 'description',
+      className: 'overflow-hidden',
+      ellipsis: true,
       width: '15%',
+      render: (text, record) => <ReactMarkdown children={text} />
     },
     {
       width: '10%',
@@ -122,7 +126,7 @@ class QueryTable extends Component {
       dataIndex: 'createdAt',
       render: (text, record) => {
         let createdAt = new Date(text);
-        return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US') 
+        return createdAt.toLocaleDateString('en-US', Constants.DATE_FORMAT_OPTIONS) +' @ '+ createdAt.toLocaleTimeString('en-US')
       }
     },
     {
@@ -145,7 +149,7 @@ class QueryTable extends Component {
             columns={queryColumns}
             rowKey={record => record.id}
             dataSource={this.state.queries}
-            pagination={{ pageSize: 10 }} 
+            pagination={{ pageSize: 10 }}
             scroll={{ y: '70vh' }}
           />
         {this.state.openQueryDetailsDialog ?
@@ -154,7 +158,7 @@ class QueryTable extends Component {
             selectedAsset={this.state.selectedQuery}
             applicationId={this.props.applicationId}
             onRefresh={this.handleRefreshTree}
-            onClose={this.handleClose} 
+            onClose={this.handleClose}
             isNew={false}
             user={this.props.user}/>: null}
       </div>

--- a/client-reactjs/src/components/common/MarkdownEditor.js
+++ b/client-reactjs/src/components/common/MarkdownEditor.js
@@ -11,12 +11,16 @@ class MarkdownEditor extends Component {
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
+    if (!this.props.value) {
+      this.mdEditor.markdown("");
+      return;
+    }
     if (!this.value) {
       this.name = this.props.name;
       this.value = this.props.value;
       let t = window.setTimeout(() => {
         this.mdEditor.markdown(this.props.value);
-      }, 400);
+      }, 300);
     }
   }
 
@@ -29,6 +33,17 @@ class MarkdownEditor extends Component {
       this.value = this.mdEditor.markdown();
       this.props.onChange({ target: this });
     }, 500));
+
+    if (!this.value) {
+      this.name = this.props.name;
+      this.value = this.props.value;
+      let t = window.setTimeout(() => {
+        if (!this.props.value) {
+          return;
+        }
+        this.mdEditor.markdown(this.props.value);
+      }, 300);
+    }
   }
 
   render() {

--- a/client-reactjs/src/index.css
+++ b/client-reactjs/src/index.css
@@ -427,6 +427,16 @@ div.tooltip {
   display:block;
 }
 
+.overflow-hidden > * {
+  overflow: hidden;
+}
+
+td.ant-table-row-cell-ellipsis::after {
+  content: "...";
+  position: absolute;
+  bottom: 16px;
+}
+
 div.tooltip {
   position: absolute;
   text-align: left;

--- a/server/migrations/20201123211743-change-length-of-description-fields.js
+++ b/server/migrations/20201123211743-change-length-of-description-fields.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.changeColumn('application', 'description', { type: Sequelize.TEXT }),
+      queryInterface.changeColumn('datadictionary', 'description', { type: Sequelize.TEXT }),
+      queryInterface.changeColumn('dataflow', 'description', { type: Sequelize.TEXT }),
+      queryInterface.changeColumn('file', 'description', { type: Sequelize.TEXT }),
+      queryInterface.changeColumn('indexes', 'description', { type: Sequelize.TEXT }),
+      queryInterface.changeColumn('job', 'description', { type: Sequelize.TEXT }),
+      queryInterface.changeColumn('jobfile', 'description', { type: Sequelize.TEXT }),
+      queryInterface.changeColumn('query', 'description', { type: Sequelize.TEXT }),
+      queryInterface.changeColumn('workflows', 'description', { type: Sequelize.TEXT })
+    ]);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.changeColumn('application', 'description', { type: Sequelize.STRING }),
+      queryInterface.changeColumn('datadictionary', 'description', { type: Sequelize.STRING }),
+      queryInterface.changeColumn('dataflow', 'description', { type: Sequelize.STRING }),
+      queryInterface.changeColumn('file', 'description', { type: Sequelize.STRING }),
+      queryInterface.changeColumn('indexes', 'description', { type: Sequelize.STRING }),
+      queryInterface.changeColumn('job', 'description', { type: Sequelize.STRING }),
+      queryInterface.changeColumn('jobfile', 'description', { type: Sequelize.STRING }),
+      queryInterface.changeColumn('query', 'description', { type: Sequelize.STRING }),
+      queryInterface.changeColumn('workflows', 'description', { type: Sequelize.STRING })
+    ]);
+  }
+};

--- a/server/models/application.js
+++ b/server/models/application.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
       autoIncrement: false
     },
     title: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     creator: DataTypes.STRING
   }, {freezeTableName: true});
   application.associate = function(models) {

--- a/server/models/datadictionary.js
+++ b/server/models/datadictionary.js
@@ -10,7 +10,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     applicationId: DataTypes.STRING,
     name: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     data_defn: {
       type: DataTypes.TEXT,
       get() {

--- a/server/models/dataflow.js
+++ b/server/models/dataflow.js
@@ -8,9 +8,9 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       autoIncrement: false
     },
-    application_id: DataTypes.STRING,    
+    application_id: DataTypes.STRING,
     title: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     input: DataTypes.STRING,
     output: DataTypes.STRING,
     clusterId: DataTypes.UUIDV4,

--- a/server/models/file.js
+++ b/server/models/file.js
@@ -12,7 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     title: DataTypes.STRING,
     name: DataTypes.STRING,
     cluster_id: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     fileType: DataTypes.STRING,
     isSuperFile: DataTypes.STRING,
     serviceURL: DataTypes.STRING,

--- a/server/models/indexes.js
+++ b/server/models/indexes.js
@@ -11,7 +11,7 @@ module.exports = (sequelize, DataTypes) => {
     application_id: DataTypes.STRING,
     title: DataTypes.STRING,
     name: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     primaryService: DataTypes.STRING,
     backupService: DataTypes.STRING,
     qualifiedPath: DataTypes.STRING,

--- a/server/models/job.js
+++ b/server/models/job.js
@@ -11,7 +11,7 @@ module.exports = (sequelize, DataTypes) => {
     application_id: DataTypes.STRING,
     author: DataTypes.STRING,
     contact: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     ecl: DataTypes.TEXT,
     entryBWR: DataTypes.STRING,
     gitRepo: DataTypes.STRING,

--- a/server/models/jobfile.js
+++ b/server/models/jobfile.js
@@ -12,7 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     application_id: DataTypes.STRING,
     file_type: DataTypes.STRING,
     name: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     file_id: DataTypes.STRING
   }, {freezeTableName: true});
   jobfile.associate = function(models) {

--- a/server/models/query.js
+++ b/server/models/query.js
@@ -11,7 +11,7 @@ module.exports = (sequelize, DataTypes) => {
     application_id: DataTypes.STRING,
     title: DataTypes.STRING,
     name: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     url: DataTypes.STRING,
     gitRepo: DataTypes.STRING,
     primaryService: DataTypes.STRING,
@@ -23,7 +23,7 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey:'query_id',
       onDelete: 'CASCADE',
       hooks: true
-    });    
+    });
     query.belongsTo(models.application, {
       foreignKey: 'application_id'
     });

--- a/server/models/workflow.js
+++ b/server/models/workflow.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
       autoIncrement: false
     },
     name: DataTypes.STRING,
-    description: DataTypes.STRING,
+    description: DataTypes.TEXT,
     application_id: DataTypes.STRING,
     dataflowId: DataTypes.STRING,
     status: DataTypes.STRING

--- a/server/routes/app/read.js
+++ b/server/routes/app/read.js
@@ -78,8 +78,7 @@ router.post('/newapp', [
   body('title')
     .matches(/^[a-zA-Z]{1}[a-zA-Z0-9_:.\-]*$/).withMessage('Invalid title'),
   body('description')
-    .optional({checkFalsy:true})
-    .matches(/^[a-zA-Z]{1}[a-zA-Z0-9_.\-]*$/).withMessage('Invalid description'),
+    .optional({checkFalsy:true}),
   body('creator')
     .matches(/^[a-zA-Z]{1}[a-zA-Z0-9_:.\-]*$/).withMessage('Invalid creator'),
 ],function (req, res) {


### PR DESCRIPTION
closes #158, closes #159 

squashed commit messages below:
- fix issue preventing the editing and saving of an application
- fix issue if value is undefined, calling .markdown() would throw
- change the description field for applications to a markdown editor component
- remove regex validator for application description, which is now markdown
- "default" width of form fields in application edit form should be wider
- add react-markdown as dependency, use this component to render md description of applications
- change description field from Input to MarkdownEditor
- "default" width of form fields in dataflow edit form should be wider
- render dataflow description as markdown preview
- change description fields in various models to accomodate arbitrary markdown (to the limit of mysql's text datatype)
- shorten application description with ellipsis: true
- render index description as markdown preview
- correct a couple of issues with MarkdownEditor, (1) not resetting properly after editing, and (2) not initializing correctly when editing
- adding a class and some styling to handle ant Table columns using the "ellipsis" option, which sets all child overflow to hidden and appends an "..." at the end of content
- adding ellipsis property and overflow class to DataflowTable and IndexTree components
- adding ReactMarkdown preview for description in DataDictionaryTable, FileTable, JobList and QueryTable