### PR TITLE
change assets & dataflows to many-to-many relationship

### DIFF
--- a/server/migrations/20210113165547-create-assets-to-dataflows.js
+++ b/server/migrations/20210113165547-create-assets-to-dataflows.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('assets_dataflows', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID
+      },
+      assetId: {
+        allowNull: false,
+        type: Sequelize.UUID
+      },
+      dataflowId: {
+        allowNull: false,
+        type: Sequelize.UUID
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('assets_dataflows');
+  }
+};

--- a/server/models/assets_dataflows.js
+++ b/server/models/assets_dataflows.js
@@ -1,0 +1,16 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const assets_dataflows = sequelize.define('assets_dataflows', {
+    id: {
+      primaryKey: true,
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      allowNull: false,
+      autoIncrement: false
+    },
+    assetId: DataTypes.UUID,
+    dataflowId: DataTypes.UUID,
+  }, {freezeTableName: true});
+
+  return assets_dataflows;
+};

--- a/server/models/file.js
+++ b/server/models/file.js
@@ -19,7 +19,6 @@ module.exports = (sequelize, DataTypes) => {
     qualifiedPath: DataTypes.STRING,
     consumer: DataTypes.STRING,
     supplier: DataTypes.STRING,
-    dataflowId: DataTypes.UUIDV4,
     scope: DataTypes.STRING
   }, {freezeTableName: true});
   file.associate = function(models) {
@@ -51,7 +50,12 @@ module.exports = (sequelize, DataTypes) => {
     file.belongsTo(models.application, {
       foreignKey: 'application_id'
     });
-    file.belongsTo(models.dataflow);
+    file.belongsToMany(models.dataflow, {
+      through: 'assets_dataflows',
+      as: 'dataflows',
+      foreignKey: 'assetId',
+      otherKey: 'dataflowId'
+    });
     file.hasMany(models.consumer_object,{
       foreignKey:'consumer_id',
       onDelete: 'CASCADE',

--- a/server/models/indexes.js
+++ b/server/models/indexes.js
@@ -18,8 +18,7 @@ module.exports = (sequelize, DataTypes) => {
     parentFileId: DataTypes.STRING,
     registrationTime: DataTypes.STRING,
     updatedDateTime: DataTypes.STRING,
-    dataLastUpdatedTime: DataTypes.STRING,
-    dataflowId: DataTypes.UUIDV4
+    dataLastUpdatedTime: DataTypes.STRING
   }, {freezeTableName: true});
   indexes.associate = function(models) {
     indexes.hasMany(models.index_key,{
@@ -35,7 +34,12 @@ module.exports = (sequelize, DataTypes) => {
     indexes.belongsTo(models.application, {
       foreignKey: 'application_id'
     });
-    indexes.belongsTo(models.dataflow);
+    indexes.belongsToMany(models.dataflow, {
+      through: 'assets_dataflows',
+      as: 'dataflows',
+      foreignKey: 'assetId',
+      otherKey: 'dataflowId'
+    });
     indexes.belongsTo(models.file, {
       foreignKey: 'parentFileId'
     });

--- a/server/models/job.js
+++ b/server/models/job.js
@@ -17,8 +17,7 @@ module.exports = (sequelize, DataTypes) => {
     gitRepo: DataTypes.STRING,
     jobType: DataTypes.STRING,
     title: DataTypes.STRING,
-    name: DataTypes.STRING,
-    dataflowId: DataTypes.UUIDV4
+    name: DataTypes.STRING
   }, {freezeTableName: true});
   job.associate = function(models) {
     job.hasMany(models.jobfile,{
@@ -31,7 +30,12 @@ module.exports = (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
       hooks: true
     });
-    job.belongsTo(models.dataflow);
+    job.belongsToMany(models.dataflow, {
+      through: 'assets_dataflows',
+      as: 'dataflows',
+      foreignKey: 'assetId',
+      otherKey: 'dataflowId'
+    });
     job.belongsTo(models.application, {
       foreignKey: 'application_id'
     });

--- a/server/models/query.js
+++ b/server/models/query.js
@@ -24,6 +24,12 @@ module.exports = (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
       hooks: true
     });
+    query.belongsToMany(models.dataflow, {
+      through: 'assets_dataflows',
+      as: 'dataflows',
+      foreignKey: 'assetId',
+      otherKey: 'dataflowId'
+    });
     query.belongsTo(models.application, {
       foreignKey: 'application_id'
     });

--- a/server/routes/dataflows/dataflow.js
+++ b/server/routes/dataflows/dataflow.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 let mongoose = require('mongoose');
 var models  = require('../../models');
+let AssetDataflow = models.assets_dataflows;
 let Dataflow = models.dataflow;
 let DataflowGraph = models.dataflowgraph;
 let Index = models.indexes;
@@ -75,6 +76,26 @@ router.post('/save', [
     } catch (err) {
         console.log('err', err);
     }
+});
+
+router.post('/saveAsset', (req, res) => {
+  AssetDataflow.findOne({
+    where: {
+      assetId: req.body.assetId,
+      dataflowId: req.body.dataflowId
+    }
+  }).then(async assetDataflow => {
+    if (assetDataflow === null) {
+      assetDataflow = await AssetDataflow.create({
+        assetId: req.body.assetId,
+        dataflowId: req.body.dataflowId
+      });
+      console.log(`assetDataflow created: ${JSON.stringify(assetDataflow.dataValues)}`);
+      return res.json({ success: true, message: `asset ${assetDataflow.assetId} added to dataflow ${assetDataflow.dataflowId}` });
+    }
+    console.log(`assetDataflow found: ${JSON.stringify(assetDataflow.dataValues)}`);
+    return res.json({ success: true, message: `asset ${assetDataflow.assetId} already associated to dataflow ${assetDataflow.dataflowId}` });
+  });
 });
 
 router.get('/', [

--- a/server/routes/dataflows/dataflowgraph.js
+++ b/server/routes/dataflows/dataflowgraph.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 let mongoose = require('mongoose');
 var models  = require('../../models');
+let AssetDataflow = models.assets_dataflows;
 let DataflowGraph = models.dataflowgraph;
 let Dataflow = models.dataflow;
 const validatorUtil = require('../../utils/validator');
@@ -148,8 +149,11 @@ router.post('/deleteAsset', [
         DataflowGraph.update(
             {nodes:JSON.stringify(nodes), edges:JSON.stringify(edges)},
             {where:{"id": DataflowGraphId, "application_id":req.body.application_id}}
-        ).then(function(updated) {
-            res.json({"result":"success"});
+        ).then(async function(updated) {
+          if (body('id').isUUID(4)) {
+            await AssetDataflow.destroy({ where: { dataflowId: req.body.dataflowId, assetId: assetId } }).catch(err => console.log(err));
+          }
+          res.json({"result":"success"});
         }).catch(function(err) {
             console.log(err);
         });

--- a/server/routes/file/read.js
+++ b/server/routes/file/read.js
@@ -41,7 +41,7 @@ router.get('/file_list', [
     }
     console.log("[file list/read.js] - Get file list for app_id = " + req.query.app_id);
     try {
-        File.findAll({where:{"application_id":req.query.app_id}, include: [Dataflow], order: [['createdAt', 'DESC']]}).then(function(files) {
+        File.findAll({where:{"application_id":req.query.app_id}, include: ['dataflows'], order: [['createdAt', 'DESC']]}).then(function(files) {
             res.json(files);
         })
         .catch(function(err) {

--- a/server/routes/index/read.js
+++ b/server/routes/index/read.js
@@ -19,7 +19,7 @@ router.get('/index_list', [
         return res.status(422).json({ success: false, errors: errors.array() });
     }
     console.log("[index/read.js] - Get file list for app_id = " + req.query.app_id);
-    Index.findAll({where:{"application_id":req.query.app_id},include: [File, Dataflow], order: [['createdAt', 'DESC']]}).then(function(indexes) {
+    Index.findAll({where:{"application_id":req.query.app_id},include: [File, 'dataflows'], order: [['createdAt', 'DESC']]}).then(function(indexes) {
         res.json(indexes);
     })
     .catch(function(err) {

--- a/server/routes/job/read.js
+++ b/server/routes/job/read.js
@@ -206,7 +206,7 @@ router.get('/job_list', [
   }
   console.log("[job list/read.js] - Get job list for app_id = " + req.query.app_id);
   try {
-    Job.findAll({where:{"application_Id":req.query.app_id}, include:[Dataflow], order: [['createdAt', 'DESC']]}).then(function(jobs) {
+    Job.findAll({where:{"application_Id":req.query.app_id}, include:['dataflows'], order: [['createdAt', 'DESC']]}).then(function(jobs) {
         res.json(jobs);
     })
     .catch(function(err) {


### PR DESCRIPTION
squashed commit messages below:

- create assets_dataflows relational table and model, alter asset models (file, index, job, query)
- change include definitions to use the "as" name/label which is defined in each asset model's associations
- when adding an asset to a dataflow graph, save the association in assets_dataflows table
- when deleting assets from dataflow graphs, don't destroy the actual asset, only the relation
- change the "end" event listener callback to only call updateGraph & saveGraph after a drag, not any mouse event
- this was causing a race condition between network requests for "save" and "deleteAsset"
- in deleteAsset, destroy the AssetDataflow relationship
- define saveAsset route in dataflow router