### PR TITLE
File  template sample file layout file Optional

### DIFF
--- a/server/models/fileTemplate.js
+++ b/server/models/fileTemplate.js
@@ -26,13 +26,16 @@ module.exports = (sequelize, DataTypes) => {
     },
     sampleLayoutFile : {
       type : DataTypes.STRING,
-      allowNull : false
+      allowNull : true
     },
     cluster_id: {
       type : DataTypes.STRING,
       allowNull: false
     },
-    description: DataTypes.TEXT,
+    description:{
+      type: DataTypes.TEXT,
+      allowNull : true
+    },
     metaData : {
       type: DataTypes.JSON,
       allowNull : true


### PR DESCRIPTION
Since we are picking the sample file in the background, sometimes the the files array could be empty and there are no files to pick. For example if a user tries to create a template with .txt as a search string and if there are 0 files that contain .txt then the  file array is empty. 