### PR TITLE
Kostas/publishing job

### DIFF
--- a/client-reactjs/src/components/application/DataflowInstances/JobExecutionDetails.js
+++ b/client-reactjs/src/components/application/DataflowInstances/JobExecutionDetails.js
@@ -41,6 +41,7 @@ function JobExecutionDetails({ jobExecutions, setFilters, selectJEGroup, JEGroup
   const setBadgeColor = (status) => {
     const colors = {
       completed: '#3bb44a',
+      compiled: '#3bb44a',
       failed: '#FF0000',
       blocked: '#FFA500',
       'some-failed': '#FFA500',
@@ -50,7 +51,7 @@ function JobExecutionDetails({ jobExecutions, setFilters, selectJEGroup, JEGroup
   };
 
   const getGroupStatus = (statuses) => {
-    if (statuses.every((status) => status === 'completed')) return 'completed';
+    if (statuses.every((status) => status === 'completed' || status === 'compiled')) return 'completed';
     if (statuses.some((status) => status === 'failed' || status === 'error')) return 'failed';
     if (statuses.some((status) => status === 'wait' || status === 'submitted')) return 'in-progress';
     return 'some-failed';

--- a/client-reactjs/src/components/application/Graph/GraphX6.js
+++ b/client-reactjs/src/components/application/Graph/GraphX6.js
@@ -158,6 +158,7 @@ function GraphX6({ readOnly = false, monitoring, statuses }) {
     const graph = Canvas.init(graphContainerRef, miniMapContainerRef, readOnly);
     graph.dataflowId = dataflowId; //adding dataflowId value to graph instance to avoid pulling it from redux everywhere;
     graphRef.current = graph;
+    graphRef.current.allowExecute = false; // default state, jobs can not be executed unless on LIVE graph;
 
     Shape.init({ handleContextMenu, disableContextMenu: readOnly , graph});
 
@@ -917,6 +918,7 @@ function GraphX6({ readOnly = false, monitoring, statuses }) {
           onClose={updateAsset}
           addToSchedule={addToSchedule}
           viewMode={readOnly} // THIS PROP WILL REMOVE EDIT OPTIONS FROM MODAL
+          allowExecute={graphRef.current.allowExecute}
           displayingInModal={true} // used for control button in modals
           selectedAsset={{ // all we know about clicked asset will be passed in selectedAsset prop
             id: configDialog.assetId,

--- a/client-reactjs/src/components/application/Graph/Shape.css
+++ b/client-reactjs/src/components/application/Graph/Shape.css
@@ -41,7 +41,7 @@
     right: 3px;
   }
 
-  .Job, .Manual {
+  .Job, .Manual , .Query-Publish {
     background-color: #ffa726; 
     border: 2px solid #c25e00; 
   }
@@ -93,7 +93,7 @@
     align-items: center;
   }
   
-  .status-completed, .status-completed:hover, .status-compiled {
+  .status-completed, .status-completed:hover, .status-compiled, .status-compiled:hover {
     border-color:#04880a;
     box-shadow: 0px 0px 8px 2px #08a710
   }

--- a/client-reactjs/src/components/application/Graph/Shape.js
+++ b/client-reactjs/src/components/application/Graph/Shape.js
@@ -16,6 +16,7 @@ import {
   LinkOutlined,
   MessageOutlined,
   MailOutlined,
+  SoundOutlined,
   ProfileOutlined,
   FileSearchOutlined
 } from '@ant-design/icons/lib/icons';
@@ -142,6 +143,7 @@ class Node extends React.Component {
     Monitor: <FileSearchOutlined />,
     Index: <BookOutlined />,
     Manual: <MailOutlined />,
+    'Query-Publish': <SoundOutlined />,
     'Sub-Process': <SisternodeOutlined />,
   };
 
@@ -161,6 +163,8 @@ class Node extends React.Component {
     };
 
     if (jobType === 'Manual') type = 'Manual'; // Show different icon for Manual job
+    if (jobType === 'Query Publish') type = 'Query-Publish'; // Show different icon for Query Publish jobs
+
     if (isSuperFile) type = 'SuperFile';// Show different icon for SuperFile
     if (isMonitoring) type = 'Monitor'; // used for fileTemplateMonitoring, shows different icon and background
 

--- a/client-reactjs/src/components/application/Graph/Toolbar/Legend.js
+++ b/client-reactjs/src/components/application/Graph/Toolbar/Legend.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { List, Typography } from 'antd';
-import { HourglassOutlined,ProfileOutlined, ArrowRightOutlined, SettingOutlined, EyeInvisibleOutlined, FileAddOutlined, MailOutlined} from '@ant-design/icons/lib/icons';
+import { HourglassOutlined,ProfileOutlined, ArrowRightOutlined, SettingOutlined, EyeInvisibleOutlined, FileAddOutlined, MailOutlined, SoundOutlined} from '@ant-design/icons/lib/icons';
 import { colors } from '../graphColorsConfig';
 
 const { Text } = Typography;
@@ -57,6 +57,10 @@ const data = [
   {
     title: 'Manual Job',
     icon: <MailOutlined className="Job legend-icon" />,
+  },
+  {
+    title: 'Query Publish Job',
+    icon: <SoundOutlined className="Job legend-icon" />,
   },
   {
     title: 'Hide node (use "Hidden Nodes" tab to display them)',

--- a/client-reactjs/src/components/application/Graph/Toolbar/VersionsButton.js
+++ b/client-reactjs/src/components/application/Graph/Toolbar/VersionsButton.js
@@ -159,6 +159,9 @@ const VersionsButton = ({ graphRef }) => {
       }else{
         // When change is not permanent we need to cancel most of the interactions to avoid editing graph.
         graphRef.current.freeze().disableSelection().disableRubberband().disableSnapline().disableSharpSnapline().hideTools();
+
+        // Only Live Versions can be executed, update the flag it will reflect in modal action buttons;
+        graphRef.current.allowExecute = version.isLive;
         
         // Notify user about read-only view
         notification.info({
@@ -331,6 +334,7 @@ const VersionsButton = ({ graphRef }) => {
   }
 
   const getWorkingCopy = () =>{
+    graphRef.current.allowExecute = false; // making sure you can not execute graph that is in localStorage
     const dataflowId = graphRef.current.dataflowId;
     const wcGraph = getWorkingCopyGraph(dataflowId);
 

--- a/client-reactjs/src/components/application/Jobs/BasicsTabGeneral.js
+++ b/client-reactjs/src/components/application/Jobs/BasicsTabGeneral.js
@@ -32,7 +32,11 @@ function BasicsTabGeneral({ enableEdit, editingAllowed, addingNewAsset, jobType,
       const options = {
         method: 'POST',
         headers: authHeader(),
-        body: JSON.stringify({ clusterid: clusterId, keyword: searchString.trim(), indexSearch: true })
+        body: JSON.stringify({
+          keyword: searchString.trim(),
+          clusterId, 
+          clusterType: jobType === "Query Publish" ? 'roxie': '', 
+        })
       }; 
       
       const response = await fetch('/api/hpcc/read/jobsearch', options);
@@ -55,7 +59,7 @@ function BasicsTabGeneral({ enableEdit, editingAllowed, addingNewAsset, jobType,
       setSearch(prev => ({...prev, loading:false, error: error.message }))
     }
   }, 500)
-  , []);
+  , [jobType, clusterId]);
  
     const resetModal = () => {
       //this method is triggered when we click any of buttons on modal;

--- a/client-reactjs/src/components/application/Jobs/JobDetails.js
+++ b/client-reactjs/src/components/application/Jobs/JobDetails.js
@@ -521,11 +521,6 @@ class JobDetails extends Component {
 
     const { confirmLoading, jobTypes, sourceFiles } = this.state;
 
-    const eclItemLayout = {
-      labelCol: { xs: { span: 2 }, sm: { span: 2 }, md: { span: 2 }, lg: { span: 2 }, },
-      wrapperCol: { xs: { span: 4 }, sm: { span: 24 }, md: { span: 24 }, lg: { span: 24 }, xl: { span: 24 }, },
-    };
-
     const longFieldLayout = {
       labelCol: { span: 2 },
       wrapperCol: { span: 12 },
@@ -584,18 +579,43 @@ class JobDetails extends Component {
       this.setState({ enableEdit: !this.state.enableEdit, editing: false, dataAltered: true, });
     };
 
+    // show control buttons at the bottom of modal
+    const getModalControls = () => {
+      // if on "Schedule Tab" (#6) hide controls
+      if (this.state.selectedTabPaneKey === "6") return null;    
+      // if read only show only execute button or nothing
+      if (this.props.viewMode) return getExecuteJobBtn()
+      // if not readonly show controls for editing and deleting;
+      return controls;
+    };
+
+    const getExecuteJobBtn = () =>{
+      // if opened in not LIVE dataflow - hide execute button;
+      if (this.props.displayingInModal && !this.props.allowExecute) return null;
+      // if opened in LIVE dataflow - show execute button inside grey frame wrapper;
+      if (this.props.displayingInModal && this.props.allowExecute) {
+        return (
+          <div className="assetDetail-buttons-wrapper-modal">
+            <Button disabled={!editingAllowed} type="primary" onClick={this.executeJob}>
+              Execute Job
+            </Button>
+          </div>
+        )
+      }
+      // if opened in main view show button as dissabled (click edit to enable)
+      return (
+        <Button disabled={!editingAllowed || !this.state.enableEdit} type="primary" onClick={this.executeJob}>
+          Execute Job
+        </Button>
+      )
+    }
+    
+
     //controls
     const controls = (
       <div className={ this.props.displayingInModal ? 'assetDetail-buttons-wrapper-modal' : 'assetDetail-buttons-wrapper ' } >
         <span style={{ float: 'left' }}>
-          <Button
-            disabled={!editingAllowed || !this.state.enableEdit}
-            type="primary"
-            key="execute"
-            onClick={this.executeJob}
-          >
-            Execute Job
-          </Button>
+          {getExecuteJobBtn()}
         </span>
     
         <span className="button-container">
@@ -888,11 +908,7 @@ class JobDetails extends Component {
           </Tabs>
         </Form>
       </div>
-      {this.props.displayingInModal
-       && !this.props.viewMode
-        && this.state.selectedTabPaneKey !== '6' // if on schedule tab, hide controls
-        ? controls
-         : null}
+      {this.props.displayingInModal ? getModalControls() : null}
     </React.Fragment>
     );
   }

--- a/client-reactjs/src/components/application/Jobs/JobDetails.js
+++ b/client-reactjs/src/components/application/Jobs/JobDetails.js
@@ -32,7 +32,7 @@ class JobDetails extends Component {
     visible: true,
     confirmLoading: false,
     loading: false,
-    jobTypes: [ "Data Profile", "ETL", "Job", "Manual", "Modeling", "Query Build", "Scoring", "Script", "Spray", ],
+    jobTypes: [ "Data Profile", "ETL", "Job", "Manual", "Query Publish", "Modeling", "Query Build", "Scoring", "Script", "Spray", ],
     paramName: "",
     paramType: "",
     sourceFiles: [],

--- a/server/jobs/statusPoller.js
+++ b/server/jobs/statusPoller.js
@@ -1,104 +1,93 @@
-const { parentPort, workerData } = require('worker_threads');
-const hpccUtil = require('../utils/hpcc-util');
-const assetUtil = require('../utils/assets.js');
-const workflowUtil = require('../utils/workflow-util.js');
-const models = require('../models');
-const Dataflow = models.dataflow;
-const Cluster = models.cluster;
-const { log, dispatch } = require('./workerUtils')(parentPort);
+const { parentPort, workerData } = require("worker_threads");
+const hpccUtil = require("../utils/hpcc-util");
+const assetUtil = require("../utils/assets.js");
+const workflowUtil = require("../utils/workflow-util.js");
+
+const { log, dispatch } = require("./workerUtils")(parentPort);
 
 let isCancelled = false;
 if (parentPort) {
-  parentPort.once('message', (message) => {
-    if (message === 'cancel') isCancelled = true;
+  parentPort.once("message", (message) => {
+    if (message === "cancel") isCancelled = true;
   });
 }
 
 (async () => {
   try {
     const jobExecutions = await assetUtil.getJobEXecutionForProcessing();
-    if (jobExecutions.length === 0) {
-      log("verbose",'☕ NO JOBEXECUTIONS WITH STATUS "SUBMITTED" HAS BEEN FOUND');
-      return;
-    }
+    if (jobExecutions.length === 0) return  log("verbose", '☕ NO JOBEXECUTIONS WITH STATUS "SUBMITTED" HAS BEEN FOUND');
 
-    for (let i = 0; i < jobExecutions.length; i++) {
-      const jobExecution = jobExecutions[i];
-      if(jobExecution && jobExecution.wuid) {
-        log("info",`💡  FOUND JOBEXECUTION FOR ${jobExecution.job.name}, (id:${jobExecution.id}) ${jobExecution.wuid} WITH STATUS= '${jobExecution.status}', PROCEED WITH CHECKING ON STATUS WITH HPCC`);
-        //check WU status
-        const wuResult = await hpccUtil.workunitInfo(jobExecution.wuid, jobExecution.clusterId).catch(error =>{
-          log("error",`💡  FOUND JOBEXECUTION FOR ${jobExecution.job.name}, (id:${jobExecution.id}) ${jobExecution.wuid} WITH STATUS= '${jobExecution.status}', PROCEED WITH CHECKING ON STATUS WITH HPCC`, error);
-          return { Workunit: { State: "error" ,Jobname : jobExecution.job.name } }
-        });
-        const WUstate = wuResult.Workunit.State;
+    for (let jobExecution of jobExecutions) {
+      // if there is no WUID in job execution then we have nothing to do here;
+      if (!jobExecution?.wuid) continue; 
+      
+      log( "info", `💡  FOUND JOBEXECUTION FOR ${jobExecution.job.name}, (id:${jobExecution.id}) ${jobExecution.wuid} WITH STATUS= '${jobExecution.status}', PROCEED WITH CHECKING ON STATUS WITH HPCC` );
+      // Main config object
+      const WUResult = {
+        State:'',
+        Exceptions:'',
+        TotalClusterTime: null,
+      };
+      
+      try {
+        // Getting info about WU from HPCC
+        const WUinfo = await hpccUtil.workunitInfo(jobExecution.wuid, jobExecution.clusterId);
 
-        //update JobExecution
-        if(WUstate === 'completed' || WUstate === 'wait' || WUstate === 'blocked' || WUstate === 'failed') {
-          const newjobExecution = { status: WUstate, wu_duration : wuResult.Workunit.TotalClusterTime || null };
-          const result = await jobExecution.update(newjobExecution,{where:{id:jobExecution.id}});
-          log("info",`✔️  JOB EXECUTION GOT UPDATED, ("${jobExecution.job.name}") ${jobExecution.id} ${result.wuid} = ${result.status} ${result.status === 'completed' ? "👍" : "🚩🚩🚩"}`);
-          log("verbose", result.toJSON());
-          if(WUstate === 'completed' || WUstate === 'failed'){
-            let workFlowURL, dataflow;
-            const cluster = await Cluster.findOne({ where: { id: jobExecution.clusterId } });
-            wuURL = `${cluster.thor_host}:${cluster.thor_port}/?Wuid=${wuResult.Workunit.Wuid}&Widget=WUDetailsWidget`;
-
-            if(jobExecution.dataValues?.dataflowId){ // If job part of workflow build a URL
-                  dataflow = await Dataflow.findOne({ where: { id: jobExecution.dataValues?.dataflowId } });
-                  workFlowURL = `${process.env.WEB_URL}/${dataflow.application_id}/dataflowinstances/dataflowInstanceDetails/${dataflow.id}/${jobExecution.jobExecutionGroupId}`
-            }
-             
-            if(WUstate === 'completed'){
-              log("verbose",`🔍  WORKER_THREAD IS DONE, PASSING CHECKING ON DEPENDING JOBS TO MAIN THREAD, "${jobExecution.job.name}" - ${jobExecution.wuid} - ${jobExecution.jobId}...`);
-              //If the job just completed is  a part of a workflow + notification not set up at workflow level -> send notification if set at job level
-              if(dataflow && dataflow?.metaData?.notification?.notify === 'Never' ){
-               log("info",`Job ${jobExecution.job.name} completed part of a workflow - No notification set at workflow level. User will be notified if notification is set at job level`);
-                await workflowUtil.notifyJobExecutionStatus({ jobId: jobExecution.jobId, clusterId: jobExecution.clusterId, wuid: jobExecution.wuid, WUstate, wuURL, cluster, workFlowURL })
-              }else if(!dataflow){ //Completed Job not a part of workflow
-                log("info",`Job ${jobExecution.job.name} completed not a part of a workflow (INDEPENDENT). User will be notified if notification is set at job level`);
-                await workflowUtil.notifyJobExecutionStatus({ jobId: jobExecution.jobId, clusterId: jobExecution.clusterId, wuid: jobExecution.wuid, WUstate, wuURL, cluster })
-              }
-              if (dataflow){ // if job was executed independently we dont have to look for schedule jobs, as we dont know what dataflow to look for
-                dispatch('scheduleNext',{ dependsOnJobId: jobExecution.jobId, dataflowId: jobExecution.dataflowId, jobExecutionGroupId: jobExecution.jobExecutionGroupId, });
-              }
-            }else{ // If job failed
-              if(!dataflow){ //Failed job not a part of workflow. Notify if notification set at job level
-                log("info",`Job ${jobExecution.job.name} failed - Not a part of workflow (INDEPENDENT) -> Notify if notification set at job level`);
-                await workflowUtil.notifyJobExecutionStatus({ jobId: jobExecution.jobId, clusterId: jobExecution.clusterId, wuid: jobExecution.wuid, WUstate, wuURL, cluster })
-              }
-              else if(dataflow && dataflow?.metaData?.notification?.notify === 'Never' ){ // Job failed part of workflow, but no notification set at workflow level
-                log("info",`Job ${jobExecution.job.name} failed - Not a part of workflow (INDEPENDENT) -> Notify if notification set at job level`);
-                await workflowUtil.notifyJobExecutionStatus({ jobId: jobExecution.jobId, clusterId: jobExecution.clusterId, wuid: jobExecution.wuid, WUstate, wuURL, workFlowURL })
-              }else if(dataflow && dataflow?.metaData?.notification?.notify !== 'Never'){ //Job is part of workflow and notification set for failed jobs at workflow level.
-                const{dataValues : {metaData : {notification : {failure_message, recipients}}}} = dataflow;
-                 if (dataflow.dataValues?.metaData?.notification?.notify === 'Always' || dataflow.dataValues?.metaData?.notification?.notify === 'Only on failure') {
-                  log("info",`Job ${jobExecution.job.name} failed - part of a workflow - Notification set at workflow level -> Notify`);
-                     await workflowUtil.notifyWorkflowExecutionStatus({recipients,
-                       failure_message, 
-                       executionStatus: 'failed', 
-                       hpccURL : wuURL, 
-                       jobName: jobExecution.job.name, 
-                       dataflowName: dataflow.title, 
-                       clusterName : cluster.name,
-                      dataflowId: dataflow.id,
-                      jobExecutionGroupId: jobExecution.jobExecutionGroupId,
-                      appId: dataflow.application_id
-                     });
-              }
-              }
-            }
+        // Workunit is found
+        if (WUinfo.Workunit) {
+          WUResult.State = WUinfo.Workunit.State,
+          WUResult.TotalClusterTime = WUinfo.Workunit?.TotalClusterTime || null;
+        } else {
+          // Workunit is not found
+          WUResult.State = 'error';
+          const exceptions = WUinfo.Exceptions?.Exception;
+          if (exceptions.length > 0){
+            WUResult.Exceptions = exceptions.map(exception => exception.Message).join(', ');
+            log('error',`EXCEPTIONS RECEIVED WHEN TRIED TO QUERY ${jobExecution.job.name} ${jobExecution.wuid}: ${WUResult.Exceptions}`)
           }
+        }
+      } catch (error) {
+        // Failed to send request to get WUinfo
+        log("error", "workunitInfo", error);
+        WUResult.State='error';
+      }
+
+      // possible WU states, if any of this states match WU state we will update our db accordingly 
+      const statuses = ["completed", "wait", "blocked", "failed", "error"];
+
+      if (statuses.includes(WUResult.State)) {
+        //update JobExecution
+        jobExecution = await jobExecution.update({ status: WUResult.State, wu_duration: WUResult.TotalClusterTime });
+        const {wuid, jobId , status, id, jobExecutionGroupId, dataflowId = "" } = jobExecution;
+        const { name: jobName } = jobExecution.job;
+        
+        log("info", `✔️  JOB EXECUTION GOT UPDATED, ("${jobName}") ${id} ${wuid} = ${status} ${status === "completed" ? "👍" : "🚩🚩🚩"}`);
+        log("verbose", jobExecution.toJSON());
+        
+        // WU state is completed, notify users, proceed to next job if executed in dataflow
+        if (WUResult.State === "completed") {
+          log("verbose", `🔍  WORKER_THREAD IS DONE, "${jobName}" - ${wuid} - ${jobId}`);
+          log("info", `Job "${jobName}" is completed, checking if notification required...`);
+          await workflowUtil.notifyJob({ dataflowId, jobExecutionGroupId, jobId, wuid, status: WUResult.State });
+
+          // Executed a single Job and we are done.
+          if (!dataflowId) continue;
+          // Go to next job execution
+          log('info',`CHECKING ON DEPENDING JOBS, dataflow: ${dataflowId} | jobExecutionGroupId : ${jobExecutionGroupId}`)
+          dispatch("scheduleNext", { dependsOnJobId: jobId, dataflowId, jobExecutionGroupId });
+        }
+      
+        // WU state is failed|error, notify users
+        if (WUResult.State === "failed" || WUResult.State === "error" ) {
+          log("error", `Job "${jobName}" failed checking if notification required...`);
+          await workflowUtil.notifyJob({ dataflowId, jobExecutionGroupId, jobId, wuid, status: WUResult.State , exceptions: WUResult.Exceptions });
+          await workflowUtil.notifyWorkflow({ dataflowId, jobExecutionGroupId, jobName, wuid, status: WUResult.State, exceptions: WUResult.Exceptions });
         }
       }
     }
   } catch (error) {
-    log("error",'Error in Status Poller', error);
+    log("error", "Error in Status Poller", error);
   } finally {
-    if (parentPort) {
-      parentPort.postMessage('done');
-    } else {
-      process.exit(0);
-    }
+    parentPort ? parentPort.postMessage("done") : process.exit(0);
   }
 })();

--- a/server/jobs/submitJob.js
+++ b/server/jobs/submitJob.js
@@ -1,78 +1,54 @@
 const { parentPort, workerData } = require("worker_threads");
-const { v4: uuidv4 } = require('uuid');
-const hpccUtil = require('../utils/hpcc-util');
-const assetUtil = require('../utils/assets.js');
-var models  = require('../models');
-let Dataflow = models.dataflow;
-const workFlowUtil = require('../utils/workflow-util');
-const { log, dispatch } = require('./workerUtils')(parentPort);
+const { v4: uuidv4 } = require("uuid");
+const hpccUtil = require("../utils/hpcc-util");
+const assetUtil = require("../utils/assets.js");
+const workflowUtil = require("../utils/workflow-util");
+const { log, dispatch } = require("./workerUtils")(parentPort);
 
 let isCancelled = false;
 if (parentPort) {
-  parentPort.once('message', (message) => {
-    if (message === 'cancel') isCancelled = true;
+  parentPort.once("message", (message) => {
+    if (message === "cancel") isCancelled = true;
   });
 }
 
 (async () => {
-  if(!workerData.jobExecutionGroupId){
-    workerData.jobExecutionGroupId = uuidv4();
-  }
+  if (!workerData.jobExecutionGroupId) workerData.jobExecutionGroupId = uuidv4();
+
+  const { clusterId, jobName, dataflowId } = workerData;
 
   try {
-    const wuDetails = await hpccUtil.getJobWuDetails(workerData.clusterId, workerData.jobName, workerData.dataflowId);
-    let wuid = wuDetails.wuid;
+    log('info',`Started submitting job ${jobName} | clusterId: ${clusterId} | dataflowId : ${dataflowId}`);
 
-    log('info',`${workerData.jobName} (WU: ${wuid}) to url ${workerData.clusterId}/WsWorkunits/WUResubmit.json?ver_=1.78`)
- 
-    let wuResubmitResult = await hpccUtil.resubmitWU(workerData.clusterId, wuid, wuDetails.cluster, workerData.dataflowId);
-    wuid = wuResubmitResult?.WURunResponse.Wuid;
-    if (!wuid) throw wuResubmitResult;
-    workerData.status = 'submitted';
-    await assetUtil.recordJobExecution(workerData, wuid);        
-    
-  } catch (err) {
-    log("error",`Error in job submit ${workerData.jobName}`, err);
-    const errorMessage = err?.WURunResponse?.Exceptions?.Exception[0]?.Message  || err;
-    workerData.status = 'error';
-    await assetUtil.recordJobExecution(workerData, '');  
-    if(workerData.dataflowId){
-      try{ // Job that failed to submit is part of workflow
-       const dataflow = await Dataflow.findOne({where : {id: workerData.dataflowId}})
-       if(dataflow?.dataValues?.metaData?.notification?.failure_message){ //If failure notification is set in Workflow level
-        const{dataValues, dataValues : {metaData : {notification : {failure_message, recipients}}}} = dataflow;
-        log('info','Error occurred while submitting a job THAT IS PART OF WORKFLOW - notification set at workflow level -> Notifying now' );
+    const result = await hpccUtil.getJobWuDetails(clusterId, jobName, dataflowId);
+    if (!result) throw new Error(`Failed to get data about job: ${jobName}`);
 
-           await  workFlowUtil.notifyWorkflowExecutionStatus({
-                executionStatus : 'error',
-                dataflowName: dataValues.title,
-                dataflowId : dataValues.id,
-                appId : dataflow.application_id,
-                failure_message,
-                recipients,
-                errorMessage,
-                jobName : workerData.jobName
-              })
+    const { wuid, wuService } = result;
+    log("info", `${workerData.jobName} (WU: ${wuid}) re-submitting`);
 
+    const response = await wuService.WUResubmit({ Wuids: [wuid], CloneWorkunit: true, ResetWorkflow: false });
 
-       }else{ // Failure notification not set in Workflow level - notify user if notification is set in Job level
-          log('info','Error occurred while submitting a job THAT IS PART OF WORKFLOW - No notification set at workflow level - notify if set at job level');
-          await workFlowUtil.notifyJobExecutionStatus({ jobId: workerData.jobId, clusterId: workerData.clusterId,  WUstate : 'not submitted', message : errorMessage });
-       }
-      }catch(err){
-        log("error",`Error in job submit ${workerData.jobName}`, err);
-      }
-    }else{//Job that failed to submit is NOT a part of Workflow notify accordingly
-          log('info','Error occurred while submitting an INDEPENDENT (not part of workflow) - Notify if notification is set at job level');
-         await workFlowUtil.notifyJobExecutionStatus({ jobId: workerData.jobId, clusterId: workerData.clusterId,  WUstate : 'not submitted', message : errorMessage });
+    if (response.Exceptions?.Exception?.length > 0) {
+      const message = response.Exceptions.Exception.map((exception) => exception.Message).join(", ");
+      throw new Error(message);
     }
-       
-  }  finally{
-    if (!workerData.isCronJob)  dispatch("remove");   // REMOVE JOB FROM BREE IF ITS NOT CRON JOB!
-    if (parentPort) {          
-      parentPort.postMessage('done');     
-    } else {
-      process.exit(0);
-    }  
+
+    const resultWuid = response?.WUs?.WU?.[0]?.WUID; // this is new wuid created
+    if (!resultWuid) throw new Error("Failed to get WU in respose");
+
+    workerData.status = "submitted";
+    await assetUtil.recordJobExecution(workerData, wuid);
+  } catch (error) {
+    log("error", `Error in job submit ${workerData.jobName}`, error);
+    workerData.status = "error";
+    await assetUtil.recordJobExecution(workerData, "");
+    
+    const {jobId, jobName, dataflowId, jobExecutionGroupId } = workerData;
+
+    await workflowUtil.notifyJob({ dataflowId, jobExecutionGroupId, jobId, status: 'error', exceptions: error.message });
+    await workflowUtil.notifyWorkflow({ dataflowId, jobExecutionGroupId, jobName, status: 'error', exceptions: error.message });
+  } finally {
+    if (!workerData.isCronJob) dispatch("remove"); // REMOVE JOB FROM BREE IF ITS NOT CRON JOB!
+    parentPort ? parentPort.postMessage("done") : process.exit(0);
   }
 })();

--- a/server/jobs/submitJob.js
+++ b/server/jobs/submitJob.js
@@ -33,11 +33,11 @@ if (parentPort) {
       throw new Error(message);
     }
 
-    const resultWuid = response?.WUs?.WU?.[0]?.WUID; // this is new wuid created
-    if (!resultWuid) throw new Error("Failed to get WU in respose");
+    const newWUID = response?.WUs?.WU?.[0]?.WUID; // this is new wuid created
+    if (!newWUID) throw new Error("Failed to get WU in respose");
 
     workerData.status = "submitted";
-    await assetUtil.recordJobExecution(workerData, wuid);
+    await assetUtil.recordJobExecution(workerData, newWUID);
   } catch (error) {
     log("error", `Error in job submit ${workerData.jobName}`, error);
     workerData.status = "error";

--- a/server/jobs/submitPublishQuery.js
+++ b/server/jobs/submitPublishQuery.js
@@ -27,7 +27,24 @@ if (parentPort) {
     const  { wuid, wuService } = result;
     log("info", `${workerData.jobName} (WU: ${wuid}) publishing`);
     
-    const response = await wuService.WUPublishWorkunit({ Wuid: wuid, JobName:jobName,  Cluster:'roxie', Activate:true });	
+    const response = await wuService.WUPublishWorkunit({
+      Wuid: wuid,
+      JobName: jobName,
+      Cluster: "roxie",
+      // https://discoverylab.hpcc.risk.regn.net:18010/WsWorkunits/WUPublishWorkunit?ver_=1.8&form  | default props must be included in order to work;
+      Activate: 1,
+      NotifyCluster: false,
+      Wait: 10000,
+      NoReload: false,
+      UpdateWorkUnitName: false,
+      DontCopyFiles: false,
+      AllowForeignFiles: false,
+      UpdateDfs: false,
+      UpdateSuperFiles: false,
+      UpdateCloneFrom: false,
+      AppendCluster: true,
+      IncludeFileErrors: false,
+    });
         
     if (response.Exceptions?.Exception?.length  > 0){
       const message = response.Exceptions.Exception.map(exception => exception.Message).join(', ');

--- a/server/jobs/submitPublishQuery.js
+++ b/server/jobs/submitPublishQuery.js
@@ -1,0 +1,70 @@
+const { parentPort, workerData } = require("worker_threads");
+const { v4: uuidv4 } = require("uuid");
+
+const workflowUtil = require("../utils/workflow-util");
+const assetUtil = require('../utils/assets.js');
+const hpccUtil = require('../utils/hpcc-util');
+
+const { log, dispatch } = require('./workerUtils')(parentPort);
+
+let isCancelled = false;
+if (parentPort) {
+  parentPort.once('message', (message) => {
+    if (message === 'cancel') isCancelled = true;
+  });
+}
+
+(async () => { 
+  try {
+    if(!workerData.jobExecutionGroupId) workerData.jobExecutionGroupId = uuidv4();
+
+    const {clusterId, jobName, dataflowId, jobId, jobExecutionGroupId } = workerData;
+    log('info',`Started Query Publish job ${jobName} | clusterId: ${clusterId} | dataflowId : ${dataflowId}`)
+
+    const result = await hpccUtil.getJobWuDetails(clusterId, jobName, dataflowId, 'roxie');
+    if (!result) throw new Error(`Failed to get data about job: ${jobName}`);
+   
+    const  { wuid, wuService } = result;
+    log("info", `${workerData.jobName} (WU: ${wuid}) publishing`);
+    
+    const response = await wuService.WUPublishWorkunit({ Wuid: wuid, JobName:jobName,  Cluster:'roxie', Activate:true });	
+        
+    if (response.Exceptions?.Exception?.length  > 0){
+      const message = response.Exceptions.Exception.map(exception => exception.Message).join(', ');
+      throw new Error(message);
+    }
+
+    const WU = await wuService.WUInfo({ Wuid: response.Wuid });
+    const status = WU.Workunit?.State;
+    if (!status) throw new Error(`Failed to get status on ${jobName} | ${response.Wuid}`)
+    
+    workerData.status = status;
+    await assetUtil.recordJobExecution(workerData, response.Wuid);
+
+    log("info", `Job "${jobName}" is ${status}, checking if notification required...`);
+    await workflowUtil.notifyJob({ dataflowId, jobExecutionGroupId, jobId, status });
+    
+    if (status !== 'compiled') {
+      // Try to notify on dataflow level about failure and exit, do not schedule next job;
+      log('error' ,`Publish Query status is not compiled: status = ${status}`)
+      return await workflowUtil.notifyWorkflow({ dataflowId, jobExecutionGroupId, jobName, status, exceptions: error.message});
+    }
+
+    if (dataflowId) {
+      dispatch("scheduleNext", { dependsOnJobId: jobId, dataflowId, jobExecutionGroupId });
+    }
+
+  } catch (error) {
+    log('error', 'Publish Query error', error);
+    workerData.status = 'error';
+    await assetUtil.recordJobExecution(workerData, '');
+        
+    const {jobId, jobName, dataflowId, jobExecutionGroupId } = workerData;
+
+    await workflowUtil.notifyJob({ dataflowId, jobExecutionGroupId, jobId, status: 'error' });
+    await workflowUtil.notifyWorkflow({ dataflowId, jobExecutionGroupId, jobName, status: 'error' });
+  } finally{
+    if (!workerData.isCronJob) dispatch("remove");   // REMOVE JOB FROM BREE IF ITS NOT CRON JOB!
+    parentPort ? parentPort.postMessage("done") : process.exit(0);
+  }
+})();

--- a/server/models/cluster.js
+++ b/server/models/cluster.js
@@ -19,6 +19,7 @@ module.exports = (sequelize, DataTypes) => {
   cluster.associate = function(models) {
     // associations can be defined here
     cluster.hasMany(models.dataflow, {foreignKey: 'clusterId' });
+    cluster.hasMany(models.job,{ foreignKey:'cluster_id', });
     cluster.hasMany(models.job_execution, {foreignKey: 'clusterId' });
     cluster.hasMany(models.dataflow_cluster_credentials,{ foreignKey:'cluster_id', });
     cluster.hasMany(models.visualizations, {foreignKey: 'clusterId', onDelete: 'CASCADE'});

--- a/server/models/job.js
+++ b/server/models/job.js
@@ -51,7 +51,9 @@ module.exports = (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
       hooks: true
     });
-
+    job.belongsTo(models.cluster, {
+      foreignKey: 'cluster_id'
+    });
     job.belongsTo(models.application, {
       foreignKey: 'application_id'
     });

--- a/server/routes/job/read.js
+++ b/server/routes/job/read.js
@@ -22,6 +22,7 @@ const { body, query, param, validationResult } = require('express-validator');
 const assetUtil = require('../../utils/assets');
 
 const SUBMIT_JOB_FILE_NAME = 'submitJob.js';
+const SUBMIT_QUERY_PUBLISH = 'submitPublishQuery.js'
 const SUBMIT_SPRAY_JOB_FILE_NAME = 'submitSprayJob.js'
 const SUBMIT_SCRIPT_JOB_FILE_NAME = 'submitScriptJob.js';
 const SUBMIT_MANUAL_JOB_FILE_NAME = 'submitManualJob.js'
@@ -732,6 +733,7 @@ router.post('/executeJob', [
     const isSprayJob = job.jobType == 'Spray';
     const isScriptJob = job.jobType == 'Script';
     const isManualJob = job.jobType === 'Manual';
+    const isQueryPublishJob= job.jobType === 'Query Publish';
     const isGitHubJob = job.metaData?.isStoredOnGithub;
     
     const commonWorkerData = { 
@@ -752,6 +754,8 @@ router.post('/executeJob', [
       status = JobScheduler.executeJob({ jobfileName: SUBMIT_MANUAL_JOB_FILE_NAME, ...commonWorkerData, status : 'wait', manualJob_meta : { jobType : 'Manual', jobName: job.name, notifiedTo : job.contact, notifiedOn : new Date().getTime() } });
     } else if (isGitHubJob) {
       status = JobScheduler.executeJob({ jobfileName: SUBMIT_GITHUB_JOB_FILE_NAME, ...commonWorkerData,  metaData : job.metaData, });
+    } else if (isQueryPublishJob) {
+      status = JobScheduler.executeJob({ jobfileName: SUBMIT_QUERY_PUBLISH, ...commonWorkerData});
     } else {
       status = JobScheduler.executeJob({ jobfileName: SUBMIT_JOB_FILE_NAME, ...commonWorkerData });
     }
@@ -860,7 +864,6 @@ router.post( '/manualJobResponse',
 );
 
 const QueueDaemon = require('../../queue-daemon');
-const logger = require('../../config/logger');
 
 router.get('/msg', (req, res) => {
   if (req.query.topic && req.query.message) {

--- a/server/utils/hpcc-util.js
+++ b/server/utils/hpcc-util.js
@@ -318,7 +318,7 @@ exports.getJobInfo = async (clusterId, jobWuid, jobType) => {
   }
 };
 
-exports.getJobWuDetails = async (clusterId, jobName, dataflowId) => {
+exports.getJobWuDetails = async (clusterId, jobName, dataflowId, clusterType="") => {
   try {
     let wuService;
 
@@ -344,10 +344,10 @@ exports.getJobWuDetails = async (clusterId, jobName, dataflowId) => {
 
     if (!wuService) throw new Error('Failed to get WorkunitsService');
 
-    const WUQuery = await wuService.WUQuery({ Jobname: jobName, PageSize: 1, PageStartFrom: 0 });
+    const WUQuery = await wuService.WUQuery({ Jobname: jobName, Cluster: clusterType, PageSize: 1, PageStartFrom: 0 });
     const ECLWorkunit = WUQuery.Workunits?.ECLWorkunit?.[0];
 
-    return ECLWorkunit ? { wuid: ECLWorkunit.Wuid, cluster: ECLWorkunit.Cluster } : null;
+    return ECLWorkunit ? { wuid: ECLWorkunit.Wuid, cluster: ECLWorkunit.Cluster, wuService } : null;
   } catch (error) {
     console.log('-ERROR getJobWuDetails-----------------------------------------');
     console.dir({ error }, { depth: null });
@@ -414,9 +414,6 @@ exports.workunitInfo = async (wuid, clusterId) => {
     const wuService = await module.exports.getWorkunitsService(clusterId);
     return  await wuService.WUInfo({"Wuid":wuid, "IncludeExceptions":true, "IncludeSourceFiles":true, "IncludeResults":true, "IncludeTotalClusterTime": true, IncludeResultsViewNames : true});
   } catch (error) {
-    console.log('---error---------------------------------------');
-    console.dir({workunitInfo}, { depth: null });
-    console.log('------------------------------------------');
     throw error;
   }
 }

--- a/server/utils/workflow-util.js
+++ b/server/utils/workflow-util.js
@@ -118,10 +118,6 @@ exports.notifyWorkflow = async ({ dataflowId, jobExecutionGroupId, status, jobNa
   
   if (action[status]) action[status](); 
 
-  console.log('------recipients------------------------------------');
-  console.dir({ to: recipients, subject: email.subject, from: process.env.EMAIL_SENDER, }, { depth: null });
-  console.log('------------------------------------------');
-
   await NotificationModule.notify({
     to: recipients,
     subject: email.subject,

--- a/server/utils/workflow-util.js
+++ b/server/utils/workflow-util.js
@@ -5,29 +5,6 @@ const Dataflow = models.dataflow;
 const Job = models.job;
 const NotificationModule = require('../routes/notifications/email-notification');
 
-exports.notifyJobFailure = async ({jobId, clusterId, wuid}) => {
-  return new Promise(async (resolve,reject) =>{
-    Job.findOne({where: {id: jobId}}).then(async (job) => {     
-      if(job.contact) {
-        let cluster = await Cluster.findOne({where: {id: clusterId}});
-        await NotificationModule.notify({
-          from: process.env.EMAIL_SENDER,
-          to: job.contact,
-          subject:`${job.name} Failed`,
-          html: `<p>Job "${job.name}" failed on "${cluster.name}" cluster</p>
-                 <p> Workunit Id:
-                   <a href="${cluster.thor_host}:${cluster.thor_port}/?Wuid=${wuid}&Widget=WUDetailsWidget">${wuid || "N/A" } </a>
-                 </p>`
-        })
-        console.log('------------------------------------------');
-        console.log(`!!!EMAIL SENT to ${job.contact}!!!`)
-        console.log('------------------------------------------');
-      }
-      resolve();
-    }).catch(reject);
-  })
-}
-
 
 // Send notification for manual jobs in a workflow
 exports.notifyManualJob = async (options) => {
@@ -76,150 +53,163 @@ exports.confirmationManualJobAction = async (options) => {
     })
 }
 
+exports.notifyWorkflow = async ({ dataflowId, jobExecutionGroupId, status, jobName='', wuid='', exceptions='' }) => {
+  if (!dataflowId) return null;
+  
+  const dataflow = await Dataflow.findOne({ where: { id: dataflowId }, include: Cluster });
+  if (!dataflow) return null;
 
-exports.notifyDependentJobsFailure = async ({contact, dataflowId, failedJobsList}) => {
- try{
-   const dataflow = await Dataflow.findOne({where: {id: dataflowId}});
-   await NotificationModule.notify({
-     from: process.env.EMAIL_SENDER,
-     to: contact,
-     subject:"Failed to execute dependent job",
-     html: `<p>Failed to execute dependent job/s in "${dataflow.title}" dataflow:</p>
-            ${failedJobsList.map(job=>{
-              return `<p>${job.jobName}</p>`
-            }).join(",")}`            
-   })
-    console.log('------------------------------------------');
-    console.log(`!!!EMAIL SENT to ${contact}!!!`)
-    console.log('------------------------------------------');
- } catch (error){
-    console.log('------------------------------------------');
-    console.dir(error, { depth: null });
-    console.log('------------------------------------------');
- }
-}
+  const { application_id, cluster } = dataflow;
+  
+  const notification = dataflow?.metaData?.notification;
+  if (!notification) return null;
 
-//Send job execution status (success / failure) notification, if user has subscribed
-exports.notifyJobExecutionStatus = async ({ jobId, clusterId, WUstate, wuURL, message, workFlowURL }) => {
-  const logNotificationStatus = (recipients, jobName, workUnitStatus, clusterName) => {
-    console.log('------------------------------------------');
-    console.log(`✉ notifying ${recipients}  about ${jobName} job execution '${workUnitStatus}' status on ${clusterName} cluster`);
-    console.log('------------------------------------------');
+  const {notify, failure_message, success_message, recipients } = notification;
+
+  const DATAFLOW_LINK =`${process.env.WEB_URL}/${application_id}/dataflowinstances/dataflowInstanceDetails/${dataflowId}/${jobExecutionGroupId}`;
+  const FAILED_HPCC_URL = `${cluster.thor_host}:${cluster.thor_port}/?Wuid=${wuid}&Widget=WUDetailsWidget`;
+  const SUCCESS_HPCC_URL = `${cluster.thor_host}:${cluster.thor_port}/#/stub/ECL-DL/Workunits-DL/Workunits`;
+
+  const statuses = {
+    failure : ['wait', 'blocked', 'failed', 'error'],
+    success : ['compiled', 'completed']
+  }
+
+  if (!notify || notify === 'Never') return null; // notifications settings on dataflow level is not provided
+  if (notify === 'Only on failure' && !statuses.failure.includes(status)) return null;
+  if (notify === 'Only on success' && !statuses.success.includes(status)) return null;
+  
+  const email = {
+    subject:'Tombolo',
+    message:''
+  }
+  
+  const action ={
+    completed : () =>{
+      email.subject = `${dataflow.title} execution successful`;
+      email.message =
+       `<div>
+          <p> Hello, </p>
+          <p> ${success_message} </p>
+          <p> To view workflow execution details in Tombolo please click <a href=${DATAFLOW_LINK}> here </a>
+          <p> Click <a href="${SUCCESS_HPCC_URL}"> here </a>to view execution details in HPCC</p> 
+        </div>`;
+    },
+    error: () =>{
+      email.subject = `Unable to submit ${jobName} for execution`;
+      email.message = 
+        `<div>
+          <p>Hello,<p>
+          <p>Below error occurred while submitting ${jobName}</p> 
+          <p><span style="color: red">${exceptions}</span>
+        </div>`;
+    },
+    failed: () =>{
+      email.subject = `${dataflow.title} Failed.`;
+      email.message = 
+        `<div>
+          <p>Hello, </p>
+          <p>${failure_message}</p>
+          <p> To view workflow execution details in Tombolo please click <a href=${DATAFLOW_LINK}> here </a>
+          <p> Click <a href="${FAILED_HPCC_URL}"> here </a>to view execution  details in HPCC</p> 
+        </div>`;
+    }
   };
-  return new Promise(async (resolve, reject) => {
-    Job.findOne({ where: { id: jobId } })
-      .then(async (job) => {
-        if (!job) {
-          console.log('------------------------------------------');
-          console.log(`Unable to notify user - Job with id ${jobId} notFound`);
-          console.log('------------------------------------------');
-        } else if (job && job.metaData.notificationSettings?.notify) {
-          let cluster = await Cluster.findOne({ where: { id: clusterId } });
-          let notify = job.metaData.notificationSettings.notify;
-          if (notify === 'Always' && WUstate !== 'not submitted' ) {
-            await NotificationModule.notify({
-              from: process.env.EMAIL_SENDER,
-              to: job.metaData.notificationSettings.recipients,
-              subject: `${job.name} ${WUstate} on ${cluster.dataValues.name} cluster`,
-              html: `<p> ${WUstate === 'failed' ? job.metaData.notificationSettings.failureMessage : job.metaData.notificationSettings.successMessage} </p>
-                     ${ workFlowURL ? `<p>To view workflow execution details in Tombolo, please click here <a href="${workFlowURL}"> here </a></p>` : ''}
-                     <p>To view details in HPCC , please click <a href = '${wuURL}'> here </a></p>
-                    <p>Tombolo</p>`,
-            });
-            logNotificationStatus(job.metaData.notificationSettings.recipients, job.name, WUstate, cluster.dataValues.name);
-          } else if (notify === 'Only on success' && WUstate === 'completed') {
-            await NotificationModule.notify({
-              from: process.env.EMAIL_SENDER,
-              to: job.metaData.notificationSettings.recipients,
-              subject: `${job.name} ${WUstate} on ${cluster.dataValues.name} cluster`,
-              html: `<p>  ${job.metaData.notificationSettings.successMessage} </p><p>Tombolo</p>`,
-            });
-            logNotificationStatus(job.metaData.notificationSettings.recipients, job.name, WUstate, cluster.dataValues.name);
-          } else if ((notify === 'Only on failure' && WUstate === 'failed')) {
-            await NotificationModule.notify({
-              from: process.env.EMAIL_SENDER,
-              to: job.metaData.notificationSettings?.recipients || job.contact,
-              subject: `${job.name} ${WUstate} on ${cluster.dataValues.name} cluster`,
-              html: `<p>  ${job.metaData.notificationSettings.failureMessage} </p>
-                     <p>To view workflow execution details in Tombolo, please click here <a href="${workFlowURL}"> here </a></p>
-                     <p>To view details in HPCC , please click <a href = '${wuURL}'> here </a></p>
-                     <p>Tombolo</p>`,
-            });
-            logNotificationStatus(job.metaData.notificationSettings.recipients, job.name, WUstate, cluster.dataValues.name);
-          }
-          else if (((notify === 'Only on failure' || notify === 'Always') && WUstate === 'not submitted')) {
-            await NotificationModule.notify({
-              from: process.env.EMAIL_SENDER,
-              to: job.metaData.notificationSettings?.recipients || job.contact,
-              subject: `${job.name} ${WUstate} on ${cluster.dataValues.name} cluster`,
-              html: `<p>  ${job.metaData.notificationSettings.failureMessage} </p>
-                    <p> Error occurred while submitting a Job </p>
-                    <p style="color : red">${message || ''}</p>
-                    <p>Tombolo</p>`,
-            });
-            logNotificationStatus(job.metaData.notificationSettings.recipients, job.name, WUstate, cluster.dataValues.name);
-          }  
-          else {
-            console.log('------------------------------------------');
-            console.log(`Not subscribed for '${WUstate}' Job Execution status for ${job.name}`);
-            console.log('------------------------------------------');
-          }
-        }
-        resolve();
-      })
-      .catch(reject);
-  });
-};
+  
+  if (action[status]) action[status](); 
 
-exports.notifyWorkflowExecutionStatus = async ({hpccURL,executionStatus,dataflowName,dataflowId,clusterName,appId,success_message, failure_message, recipients, jobExecutionGroupId, errorMessage, jobName}) => {
-  let message;
-  let subject;
-  //Email body
-  switch(executionStatus){
-    case 'completed' :
-        message = `<div>
-                        <p> Hello, </p>
-                        <p> ${success_message } </p>
-                        <p> To view workflow execution details in Tombolo please click <a href="${process.env.WEB_URL}/${appId}/dataflowinstances/dataflowInstanceDetails/${dataflowId}/${jobExecutionGroupId}"> here </a>
-                        <p> Click <a href="${hpccURL}"> here </a>to view execution  details in HPCC</p> 
-                      </div>`;
-                      break;
-    case 'error' :
-         message = `<div>
-                        <p>Hello,<p>
-                        <p> Below error occurred while submitting  ${jobName} </p> 
-                        <p><span style="color: red">${errorMessage } </span>
-                    </div>`
-                    break;
-    case 'failed':
-        message = `<div>
-                      <p>Hello , </p>
-                      <p>${failure_message}</p>
-                      <p> To view workflow execution details in Tombolo please click <a href="${process.env.WEB_URL}/${appId}/dataflowinstances/dataflowInstanceDetails/${dataflowId}/${jobExecutionGroupId}"> here </a>
-                      <p> Click <a href="${hpccURL}"> here </a>to view execution  details in HPCC</p> 
-                  </div>`
-  }
-
-  //Email subject line
-  switch (executionStatus) {
-    case 'completed':
-       subject = `${dataflowName} execution successful`;
-       break;
-    case 'error' : 
-       subject = `Unable to submit ${jobName} for execution`;
-       break;
-    case 'failed' :
-      subject = `${dataflowName} Failed.`
-  }
+  console.log('------recipients------------------------------------');
+  console.dir({ to: recipients, subject: email.subject, from: process.env.EMAIL_SENDER, }, { depth: null });
+  console.log('------------------------------------------');
 
   await NotificationModule.notify({
-            from: process.env.EMAIL_SENDER,
-            to: recipients,
-            subject: `${subject}`,
-            html: `${message} <p>Tombolo</p>`,
-          });
-  console.log('------------------------------------------');
-  console.log(`✉ ${recipients} notified of workflow status` )
-  console.log('------------------------------------------');
+    to: recipients,
+    subject: email.subject,
+    from: process.env.EMAIL_SENDER,
+    html: `${email.message} <p>Tombolo</p>`,
+  });
 
-}
+  console.log("------------------------------------------");
+  console.log(`✉ ${recipients} notified of workflow status = ${status}`);
+  console.log("------------------------------------------");
+};
+
+exports.notifyJob = async ({ jobId, status,  wuid = "", dataflowId='', jobExecutionGroupId = "",  exceptions = "" }) => {
+  if (dataflowId) {
+    // if Job is Executed in Dataflow and it has Dataflow notification level, then skip Job level notification;
+    const dataflow = await Dataflow.findOne({where:{id:dataflowId}});
+    if (dataflow?.metaData?.notification?.notify !== 'Never' ) return null;
+  }
+
+  const job = await Job.findOne({ where: { id: jobId }, include: Cluster });
+  if (!job) return null;
+
+  const { cluster, application_id, metaData  } = job;
+  const notification = metaData?.notificationSettings;
+  if (!notification) return null;
+
+  const { notify, recipients, failureMessage, successMessage } = notification;
+
+  const HPCC_URL= `${cluster.thor_host}:${cluster.thor_port}/?Wuid=${wuid}&Widget=WUDetailsWidget`;
+  const DATAFLOW_LINK=`${process.env.WEB_URL}/${application_id}/dataflowinstances/dataflowInstanceDetails/${dataflowId}/${jobExecutionGroupId}`;
+  
+  const statuses = {
+    failure: ["wait", "blocked", "failed", "error"],
+    success: ["compiled", "completed"],
+  };
+
+  if (!notify || notify === "Never") return null; // notifications settings on job level is not provided
+  if (notify === "Only on failure" && !statuses.failure.includes(status)) return null;
+  if (notify === "Only on success" && !statuses.success.includes(status)) return null;
+
+  const email = {
+    subject:'Tombolo',
+    message:''
+  };
+
+  const action ={
+    completed : () =>{
+      email.subject = `"${job.name}" execution successful`;
+      email.message =
+        `<div>
+          <p> Hello, </p>
+          <p> ${successMessage} </p>
+          ${ !dataflowId ? "" : `<p> To view workflow execution details in Tombolo please click <a href="${DATAFLOW_LINK}"> here </a></p>` }
+          <p> Click <a href="${HPCC_URL}"> here </a>to view execution details in HPCC</p> 
+        </div>`;
+    },
+    error: () =>{
+      email.subject = `Unable to submit ${job.name} for execution`;
+      email.message = 
+        `<div>
+          <p>Hello,<p>
+          <p>Below error occurred while submitting ${job.name}</p> 
+          <p><span style="color: red">${exceptions}</span>
+        </div>`;
+    },
+    failed: () =>{
+      email.subject = `Failed to execute "${job.name}": ${status} on "${cluster.name}" cluster`;
+      email.message = 
+      `<div>
+        <p>Hello, </p>
+        <p>${failureMessage}</p>
+        ${!dataflowId ? "" : `<p> To view workflow execution details in Tombolo please click <a href="${DATAFLOW_LINK}"> here </a>` }
+        <p> Click <a href="${HPCC_URL}"> here </a>to view execution  details in HPCC</p> 
+      </div>`;
+    }
+  };
+
+  // Call action depending on status to update email object that is used in email itself.
+  if (action[status]) action[status](); 
+
+  await NotificationModule.notify({
+    to: recipients,
+    subject: email.subject,
+    from: process.env.EMAIL_SENDER,
+    html: `${email.message} <p>Tombolo</p>`,
+  });
+
+  console.log("------------------------------------------");
+  console.log(`✉ ${recipients} notified of "'${job.name}" status :"${status}"`);
+  console.log("------------------------------------------");
+};


### PR DESCRIPTION
This is a little more than just a publishing job, as I have discovered a little more inconsistency along the way.
- Added two methods to notify users, one for job level, and one for workflow level. We will call notifyJob first, and notifyWorkflow second, it will sum up to only one email if the user has provided notification on both levels. 
- Only Live dataflow will have an execution button.  we will be able to execute from the middle of dataflow as well. in the future it is possible to pass dataflow version id and execute any dataflow in db, but unfortunately not the one that is in the current workspace, as it is local to your machine only.
- The query publishing job will have a separate icon as a loud speaker, and it will have the status 'compiled' instead of 'completed' to be consistent with HPCC statuses.