### PR TITLE
To avoid any additional webpack plugins besides what is in react scri…

### DIFF
--- a/client-reactjs/Dockerfile
+++ b/client-reactjs/Dockerfile
@@ -9,8 +9,7 @@ RUN npm install
 COPY . /app/
 
 # Reason why this package is copied to public folder - https://github.com/suren-atoyan/monaco-react/issues/217#issuecomment-980800802
-# https://github.com/suren-atoyan/monaco-loader#config
-COPY  node_modules/monaco-editor app/public/
+RUN cp -r node_modules/monaco-editor /app/public
 
 RUN npm run build
 

--- a/client-reactjs/Dockerfile
+++ b/client-reactjs/Dockerfile
@@ -8,6 +8,10 @@ RUN npm install
 
 COPY . /app/
 
+# Reason why this package is copied to public folder - https://github.com/suren-atoyan/monaco-react/issues/217#issuecomment-980800802
+# https://github.com/suren-atoyan/monaco-loader#config
+COPY  node_modules/monaco-editor app/public/
+
 RUN npm run build
 
 #temperory fix for hpcc-js lib causing CSP to fail

--- a/client-reactjs/src/components/common/MonacoEditor.js
+++ b/client-reactjs/src/components/common/MonacoEditor.js
@@ -1,5 +1,9 @@
 import React from 'react';
 import { default as Monaco } from '@monaco-editor/react';
+import { loader } from '@monaco-editor/react';
+
+// https://github.com/suren-atoyan/monaco-react/issues/217#issuecomment-980800802
+loader.config({ paths: { vs: '/monaco-editor/min/vs' } });
 
 const MonacoEditor = ({ onChange, value = '', targetDomId = '', lang = 'markdown', ...rest }) => {
   const config = {


### PR DESCRIPTION
…pt, monoco editor is using CDN to fetch some plugins. this is causing issue in closed environment - eg apps beside vpn. To avoid this the monoco package is pulled inside public folder. this is quick and dirty trick and there are no other options available accoring to the author of the package