### PR TITLE
Restricted scheduler picker to block hours outside the user-selected …

### DIFF
--- a/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTab.jsx
+++ b/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTab.jsx
@@ -27,6 +27,7 @@ function JobMonitoringTab({
 }) {
   const [clusterOffset, setClusterOffset] = useState(null);
 
+  // Generating cluster offset string to display in time picker
   useEffect(() => {
     if (selectedCluster?.timezone_offset === null || selectedCluster?.timezone_offset === undefined) return;
     const offSet = selectedCluster.timezone_offset / 60;
@@ -36,6 +37,30 @@ function JobMonitoringTab({
       setClusterOffset(`UTC ${offSet}`);
     }
   }, [selectedCluster]);
+
+  // When intermediate scheduling is changed clear Expected start and end time
+  useEffect(() => {
+    form.setFieldsValue({ expectedStartTime: null, expectedCompletionTime: null });
+  }, [intermittentScheduling]);
+
+  // Function to disable specific hours
+  const getDisabledTime = (type) => {
+    if (type === 'morning') {
+      return {
+        disabledHours: () => [...Array(24).keys()].filter((hour) => hour >= 12), // Disable afternoon hours
+        disabledMinutes: () => [], // No minutes are disabled
+      };
+    } else if (type === 'afternoon') {
+      return {
+        disabledHours: () => [...Array(24).keys()].filter((hour) => hour < 12), // Disable morning hours
+        disabledMinutes: () => [], // No minutes are disabled
+      };
+    }
+    return {
+      disabledHours: () => [], // Enable all hours
+      disabledMinutes: () => [], // No minutes are disabled
+    };
+  };
 
   //Redux
   const {
@@ -48,6 +73,19 @@ function JobMonitoringTab({
   const asrIntegration = integrations.some(
     (integration) => integration.name === 'ASR' && integration.application_id === applicationId
   );
+
+  // Custom validation rule to compare times
+  // Higher-order validation function to compare times with additional parameters
+  const validateCompletionTime = (runWindow) => (_, value) => {
+    const startTime = form.getFieldValue('expectedStartTime');
+
+    if (runWindow !== 'overnight') {
+      if (startTime && value && value.isBefore(startTime)) {
+        return Promise.reject(new Error(`Completion time cannot be earlier than start time.`));
+      }
+    }
+    return Promise.resolve();
+  };
 
   return (
     <div>
@@ -89,15 +127,43 @@ function JobMonitoringTab({
                 label="Expected Start Time (HH:MM) "
                 name="expectedStartTime"
                 rules={[{ required: true, message: 'Expected start time is a required' }]}>
-                <TimePicker style={{ width: '100%' }} format="HH:mm" suffixIcon={clusterOffset} />
+                <TimePicker
+                  placeholder={intermittentScheduling?.runWindow === 'overnight' ? 'Previous Day' : 'Select Time'}
+                  disabledTime={() =>
+                    getDisabledTime(
+                      intermittentScheduling?.runWindow === 'overnight'
+                        ? 'afternoon'
+                        : intermittentScheduling?.runWindow
+                    )
+                  }
+                  style={{ width: '100%' }}
+                  format="HH:mm"
+                  suffixIcon={clusterOffset}
+                  addon={() => (intermittentScheduling?.runWindow === 'overnight' ? <div>Previous Day</div> : null)}
+                  showNow={false}
+                />
               </Form.Item>
             </Col>
             <Col span={12}>
               <Form.Item
                 label="Expected Completion Time (HH:MM) "
                 name="expectedCompletionTime"
-                rules={[{ required: true, message: 'Expected completion time is a required' }]}>
-                <TimePicker style={{ width: '100%' }} format="HH:mm" suffixIcon={clusterOffset} />
+                rules={[
+                  { required: true, message: 'Expected completion time is a required' },
+                  { validator: (_, value) => validateCompletionTime(intermittentScheduling?.runWindow)(_, value) },
+                ]}>
+                <TimePicker
+                  disabledTime={() =>
+                    getDisabledTime(
+                      intermittentScheduling?.runWindow === 'overnight' ? 'morning' : intermittentScheduling?.runWindow
+                    )
+                  }
+                  style={{ width: '100%' }}
+                  format="HH:mm"
+                  suffixIcon={clusterOffset}
+                  showNow={false}
+                  addon={() => (intermittentScheduling?.runWindow === 'overnight' ? <div>Current Day</div> : null)}
+                />
               </Form.Item>
             </Col>
           </Row>


### PR DESCRIPTION
## Description
 Block hours outside the user-selected run window on Job monitoring schedule tab. This ensures users cannot accidentally select incorrect expected start and completion times. Also added a check to make sure the completion time is always more that start time.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Vulnerability fix (package bumps or CodeQL adjustments to ensure code security)
- [ ] This change requires a documentation update

## Developer Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved any conflicts with the branch I am attempting to merge to. 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have ensured that my code does not unecessarily duplicate existing cod
- [ ] I have ensured that all security checks have been passed
- [ ] All input boxes have sensible character limits applied
- [ ] Refreshing related pages puts page in a workable and sensible state  


## Reviewer Checklist
- [ ] I have pulled the branch into my local environemtn and started the project succesfully
- [ ] I have reviewed the code for proper comments and mispellings
- [ ] All input boxes have sensible character limits applied
- [ ] Refreshing related pages puts page in a workable and sensible state  
- [ ] Submitting any relevant Forms relays proper messaging to user
- [ ] I have checked that all security checks have been passed
- [ ] I have checked that all backend routes have proper validation 
