### PR TITLE
The expected start and completion time were cleared when the componen…

### DIFF
--- a/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTab.jsx
+++ b/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTab.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Card, Form, TimePicker, Row, Col, Select } from 'antd';
 
@@ -26,7 +26,7 @@ function JobMonitoringTab({
   setSelectedDomain,
 }) {
   const [clusterOffset, setClusterOffset] = useState(null);
-  const isMounted = useRef(false); // Track if the component has mounted
+  const [firstTimeLoading, setFirstTimeLoading] = useState(true);
 
   // Generating cluster offset string to display in time picker
   useEffect(() => {
@@ -39,12 +39,11 @@ function JobMonitoringTab({
     }
   }, [selectedCluster]);
 
-  // When intermediate scheduling is changed clear Expected start and end time
   useEffect(() => {
-    if (isMounted.current) {
+    if (!firstTimeLoading) {
       form.setFieldsValue({ expectedStartTime: null, expectedCompletionTime: null });
     } else {
-      isMounted.current = true; // Set to true after the first render
+      setFirstTimeLoading(false); // Set to true after the first render
     }
   }, [intermittentScheduling]);
 

--- a/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTab.jsx
+++ b/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTab.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { Card, Form, TimePicker, Row, Col, Select } from 'antd';
 
@@ -26,7 +26,7 @@ function JobMonitoringTab({
   setSelectedDomain,
 }) {
   const [clusterOffset, setClusterOffset] = useState(null);
-  const [firstTimeLoading, setFirstTimeLoading] = useState(true);
+  const isFirstRender = useRef(true);
 
   // Generating cluster offset string to display in time picker
   useEffect(() => {
@@ -39,11 +39,12 @@ function JobMonitoringTab({
     }
   }, [selectedCluster]);
 
+  // When intermittent scheduling is changed, clear Expected start and end time
   useEffect(() => {
-    if (!firstTimeLoading) {
-      form.setFieldsValue({ expectedStartTime: null, expectedCompletionTime: null });
+    if (isFirstRender.current) {
+      isFirstRender.current = false; // Set to false after the first render
     } else {
-      setFirstTimeLoading(false); // Set to true after the first render
+      form.setFieldsValue({ expectedStartTime: null, expectedCompletionTime: null });
     }
   }, [intermittentScheduling]);
 

--- a/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTab.jsx
+++ b/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTab.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { Card, Form, TimePicker, Row, Col, Select } from 'antd';
 
@@ -26,6 +26,7 @@ function JobMonitoringTab({
   setSelectedDomain,
 }) {
   const [clusterOffset, setClusterOffset] = useState(null);
+  const isMounted = useRef(false); // Track if the component has mounted
 
   // Generating cluster offset string to display in time picker
   useEffect(() => {
@@ -40,7 +41,11 @@ function JobMonitoringTab({
 
   // When intermediate scheduling is changed clear Expected start and end time
   useEffect(() => {
-    form.setFieldsValue({ expectedStartTime: null, expectedCompletionTime: null });
+    if (isMounted.current) {
+      form.setFieldsValue({ expectedStartTime: null, expectedCompletionTime: null });
+    } else {
+      isMounted.current = true; // Set to true after the first render
+    }
   }, [intermittentScheduling]);
 
   // Function to disable specific hours


### PR DESCRIPTION
## Description

Fixed issue with clearing expected start and completion times during component load. This is not intended behavior during JM update.  Previously, these fields were cleared even if the user did not intend to update them, forcing re-entry. Now, these fields are only cleared when the user modifies the run window values.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Vulnerability fix (package bumps or CodeQL adjustments to ensure code security)
- [ ] This change requires a documentation update

## Developer Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved any conflicts with the branch I am attempting to merge to. 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have ensured that my code does not unecessarily duplicate existing cod
- [ ] I have ensured that all security checks have been passed
- [ ] All input boxes have sensible character limits applied
- [ ] Refreshing related pages puts page in a workable and sensible state  


## Reviewer Checklist
- [ ] I have pulled the branch into my local environemtn and started the project succesfully
- [ ] I have reviewed the code for proper comments and mispellings
- [ ] All input boxes have sensible character limits applied
- [ ] Refreshing related pages puts page in a workable and sensible state  
- [ ] Submitting any relevant Forms relays proper messaging to user
- [ ] I have checked that all security checks have been passed
- [ ] I have checked that all backend routes have proper validation 
