### PR TITLE
Added cluster unreachable label on JM table, if a cluster for a JM is…

### DIFF
--- a/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTable.jsx
+++ b/Tombolo/client-reactjs/src/components/application/jobMonitoring/JobMonitoringTable.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Table, Tooltip, Popconfirm, message, Popover } from 'antd';
+import React, { useState, useEffect } from 'react';
+import { Table, Tooltip, Popconfirm, message, Popover, Tag } from 'antd';
 import {
   EyeOutlined,
   EditOutlined,
@@ -10,6 +10,7 @@ import {
   PauseCircleOutlined,
   CopyOutlined,
   DownOutlined,
+  WarningFilled,
 } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
@@ -41,7 +42,10 @@ const JobMonitoringTable = ({
   domains,
   allProductCategories,
   filteringJobs,
+  clusters,
 }) => {
+  // States
+  const [unreachableClusters, setUnreachableClusters] = useState([]);
   //Redux
   const {
     applicationReducer: {
@@ -53,6 +57,14 @@ const JobMonitoringTable = ({
   const asrIntegration = integrations.some(
     (integration) => integration.name === 'ASR' && integration.application_id === applicationId
   );
+
+  // Cluster that is not able to establish connection
+  useEffect(() => {
+    if (clusters.length > 0) {
+      const ids = clusters.filter((c) => c.reachabilityInfo && c.reachabilityInfo.reachable === false).map((c) => c.id);
+      setUnreachableClusters(ids);
+    }
+  }, [clusters]);
 
   // Columns for the table
   const columns = [
@@ -181,6 +193,18 @@ const JobMonitoringTable = ({
             </Popover>
           </>
         ),
+    },
+    {
+      key: (_, record) => record.id,
+      width: 80,
+      render: (_, record) => {
+        return unreachableClusters.includes(record.clusterId) ? (
+          <Tag color="black">
+            <WarningFilled style={{ color: 'yellow', fontSize: '0.8rem', marginRight: '5px' }} />
+            Cluster not reachable
+          </Tag>
+        ) : null;
+      },
     },
   ];
 

--- a/Tombolo/client-reactjs/src/components/application/jobMonitoring/index.jsx
+++ b/Tombolo/client-reactjs/src/components/application/jobMonitoring/index.jsx
@@ -665,6 +665,7 @@ function JobMonitoring() {
         productCategories={productCategories}
         allProductCategories={allProductCategories}
         filteringJobs={filteringJobs}
+        clusters={clusters}
       />
       {displayMonitoringDetailsModal && (
         <MonitoringDetailsModal


### PR DESCRIPTION
## Description

This update adds a "Cluster Unreachable" label to the Job Monitoring table for jobs with inaccessible clusters, helping users quickly identify and address connectivity issues.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Vulnerability fix (package bumps or CodeQL adjustments to ensure code security)
- [ ] This change requires a documentation update

## Developer Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved any conflicts with the branch I am attempting to merge to. 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have ensured that my code does not unecessarily duplicate existing cod
- [ ] I have ensured that all security checks have been passed
- [ ] All input boxes have sensible character limits applied
- [ ] Refreshing related pages puts page in a workable and sensible state  


## Reviewer Checklist
- [ ] I have pulled the branch into my local environemtn and started the project succesfully
- [ ] I have reviewed the code for proper comments and mispellings
- [ ] All input boxes have sensible character limits applied
- [ ] Refreshing related pages puts page in a workable and sensible state  
- [ ] Submitting any relevant Forms relays proper messaging to user
- [ ] I have checked that all security checks have been passed
- [ ] I have checked that all backend routes have proper validation 
