### PR TITLE
Potential fix for code scanning alert no. 132: Clear-text logging of sensitive information

### DIFF
--- a/Tombolo/server/controllers/userController.js
+++ b/Tombolo/server/controllers/userController.js
@@ -276,7 +276,7 @@ const changePassword = async (req, res) => {
     });
   } catch (err) {
     await t.rollback(); // Rollback on failure
-    logger.error(`Change password: ${err.message}`);
+    logger.error('Change password: An error occurred during password update.');
     return res
       .status(err.status || 500)
       .json({ success: false, message: err.message });


### PR DESCRIPTION
Potential fix for [https://github.com/hpcc-systems/Tombolo/security/code-scanning/132](https://github.com/hpcc-systems/Tombolo/security/code-scanning/132)

To fix the issue, we should avoid logging sensitive information such as password security violations. Instead, we can log a generic error message that does not expose sensitive details. The `err.message` field should be sanitized or replaced with a generic message before being passed to `logger.error`. This ensures that sensitive data is not exposed in the logs while maintaining the ability to debug errors.

**Steps to implement the fix:**
1. Modify the `catch` block in the `changePassword` function to replace `err.message` with a generic error message when logging.
2. Ensure that the original `err.message` is still returned in the HTTP response to the client, as it may be necessary for user feedback.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
