### PR TITLE
Allow duplicate monitoringName if others are deleted

### DIFF
--- a/Tombolo/server/migrations/20220507025018-create-fileMonitoring.js
+++ b/Tombolo/server/migrations/20220507025018-create-fileMonitoring.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('fileMonitoring', {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('fileMonitoring', {
       id: {
         allowNull: false,
         primaryKey: true,
@@ -48,7 +48,7 @@ module.exports = {
       },
     });
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('fileMonitoring');
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('fileMonitoring');
   },
 };

--- a/Tombolo/server/migrations/20221103135125-add-monitor-column-in-filemonitoringTable.js
+++ b/Tombolo/server/migrations/20221103135125-add-monitor-column-in-filemonitoringTable.js
@@ -3,58 +3,64 @@ module.exports = {
     const transaction = await queryInterface.sequelize.transaction();
     try {
       await queryInterface.addColumn(
-        "fileMonitoring",
-        "name",
+        'fileMonitoring',
+        'name',
         {
           type: Sequelize.DataTypes.STRING,
           allowNull: false,
-          after: "id",
+          after: 'id',
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('fileMonitoring', ['name', 'deletedAt'], {
+        unique: true,
+        name: 'fm_unique_name_deleted_at',
+      });
+
+      await queryInterface.addColumn(
+        'fileMonitoring',
+        'application_id',
+        {
+          type: Sequelize.DataTypes.STRING,
+          allowNull: false,
+          after: 'name',
         },
         { transaction }
       );
       await queryInterface.addColumn(
-        "fileMonitoring",
-        "application_id",
+        'fileMonitoring',
+        'cron',
         {
           type: Sequelize.DataTypes.STRING,
           allowNull: false,
-          after: "name",
+          after: 'application_id',
         },
+
         { transaction }
       );
+
       await queryInterface.addColumn(
-        "fileMonitoring",
-        "cron",
+        'fileMonitoring',
+        'monitoringAssetType',
         {
           type: Sequelize.DataTypes.STRING,
           allowNull: false,
-          after: "application_id",
+          after: 'cron',
         },
-
         { transaction }
       );
 
-        await queryInterface.addColumn(
-          "fileMonitoring",
-          "monitoringAssetType",
-          {
-            type: Sequelize.DataTypes.STRING,
-            allowNull: false,
-            after: "cron",
-          },
-          { transaction }
-        );
-
-          await queryInterface.addColumn(
-            "fileMonitoring",
-            "monitoringActive",
-            {
-              type: Sequelize.DataTypes.BOOLEAN,
-              allowNull: true,
-              after: "monitoringAssetType",
-            },
-            { transaction }
-          );
+      await queryInterface.addColumn(
+        'fileMonitoring',
+        'monitoringActive',
+        {
+          type: Sequelize.DataTypes.BOOLEAN,
+          allowNull: true,
+          after: 'monitoringAssetType',
+        },
+        { transaction }
+      );
 
       await transaction.commit();
     } catch (err) {
@@ -66,31 +72,27 @@ module.exports = {
   async down(queryInterface, Sequelize) {
     const transaction = await queryInterface.sequelize.transaction();
     try {
-      await queryInterface.removeColumn("fileMonitoring", "name", {
+      await queryInterface.removeColumn('fileMonitoring', 'name', {
         transaction,
       });
-      await queryInterface.removeColumn("fileMonitoring", "application_id", {
+      await queryInterface.removeColumn('fileMonitoring', 'application_id', {
         transaction,
       });
-       await queryInterface.removeColumn("fileMonitoring", "cron", {
-         transaction,
-       });
-
-       await queryInterface.removeColumn(
-         "fileMonitoring",
-         "monitoringAssetType",
-         {
-           transaction,
-         }
-       );
+      await queryInterface.removeColumn('fileMonitoring', 'cron', {
+        transaction,
+      });
 
       await queryInterface.removeColumn(
-        "fileMonitoring",
-        "monitoringActive",
+        'fileMonitoring',
+        'monitoringAssetType',
         {
           transaction,
         }
       );
+
+      await queryInterface.removeColumn('fileMonitoring', 'monitoringActive', {
+        transaction,
+      });
       await transaction.commit();
     } catch (err) {
       await transaction.rollback();

--- a/Tombolo/server/migrations/20230130135540-create-filemonitoring-superfile.js
+++ b/Tombolo/server/migrations/20230130135540-create-filemonitoring-superfile.js
@@ -1,33 +1,31 @@
-"use strict";
+'use strict';
+
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable("filemonitoring_superfiles", {
+    await queryInterface.createTable('filemonitoring_superfiles', {
       id: {
         allowNull: false,
-        autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER,
-      },
-      id: {
         type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
       },
       clusterid: {
         type: Sequelize.UUID,
         references: {
-          model: "cluster",
-          key: "id",
+          model: 'cluster',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       application_id: {
         type: Sequelize.UUID,
         references: {
-          model: "application",
-          key: "id",
+          model: 'application',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       cron: {
         type: Sequelize.STRING,
@@ -57,8 +55,16 @@ module.exports = {
         type: Sequelize.DATE,
       },
     });
+    await queryInterface.addIndex(
+      'filemonitoring_superfiles',
+      ['name', 'deletedAt'],
+      {
+        unique: true,
+        name: 'fmsf_unique_name_deleted_at',
+      }
+    );
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable("filemonitoring_superfiles");
+    await queryInterface.dropTable('filemonitoring_superfiles');
   },
 };

--- a/Tombolo/server/migrations/20230130140310-create-clusterMonitoring-table.js
+++ b/Tombolo/server/migrations/20230130140310-create-clusterMonitoring-table.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable("clusterMonitoring", {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('clusterMonitoring', {
       id: {
         allowNull: false,
         primaryKey: true,
@@ -19,25 +19,25 @@ module.exports = {
       isActive: {
         allowNull: false,
         type: Sequelize.DataTypes.BOOLEAN,
-        defaultValue: false
+        defaultValue: false,
       },
       cluster_id: {
         type: Sequelize.UUID,
         references: {
-          model: "cluster",
-          key: "id",
+          model: 'cluster',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       application_id: {
         type: Sequelize.UUID,
         references: {
-          model: "application",
-          key: "id",
+          model: 'application',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       metaData: {
         type: Sequelize.JSON,
@@ -56,8 +56,13 @@ module.exports = {
         type: Sequelize.DATE,
       },
     });
+
+    await queryInterface.addIndex('clusterMonitoring', ['name', 'deletedAt'], {
+      unique: true,
+      name: 'clm_unique_name_deleted_at',
+    });
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable("clusterMonitoring");
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('clusterMonitoring');
   },
 };

--- a/Tombolo/server/migrations/20230228142810-create-jobMonitoring-table.js
+++ b/Tombolo/server/migrations/20230228142810-create-jobMonitoring-table.js
@@ -1,7 +1,8 @@
-"use strict";
+'use strict';
+
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.createTable("jobMonitoring", {
+    await queryInterface.createTable('jobMonitoring', {
       id: {
         allowNull: false,
         primaryKey: true,
@@ -12,16 +13,15 @@ module.exports = {
         type: Sequelize.UUID,
         allowNull: false,
         references: {
-          model: "application",
-          key: "id",
+          model: 'application',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       monitoringName: {
         allowNull: false,
         type: Sequelize.STRING,
-        unique: true,
       },
       isActive: {
         allowNull: false,
@@ -29,7 +29,7 @@ module.exports = {
       },
       approvalStatus: {
         allowNull: false,
-        type: Sequelize.ENUM("Approved", "Rejected", "Pending"),
+        type: Sequelize.ENUM('Approved', 'Rejected', 'Pending'),
       },
       approvedBy: {
         allowNull: true,
@@ -55,11 +55,11 @@ module.exports = {
         type: Sequelize.UUID,
         allowNull: false,
         references: {
-          model: "cluster",
-          key: "id",
+          model: 'cluster',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "NO ACTION",
+        onUpdate: 'CASCADE',
+        onDelete: 'NO ACTION',
       },
       jobName: {
         allowNull: false,
@@ -94,8 +94,17 @@ module.exports = {
         type: Sequelize.DATE,
       },
     });
+
+    await queryInterface.addIndex(
+      'jobMonitoring',
+      ['monitoringName', 'deletedAt'],
+      {
+        unique: true,
+        name: 'jm_unique_monitoring_name_deleted_at',
+      }
+    );
   },
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.dropTable("jobMonitoring");
+    await queryInterface.dropTable('jobMonitoring');
   },
 };

--- a/Tombolo/server/migrations/20230906000000-create-OrbitMonitoring.js
+++ b/Tombolo/server/migrations/20230906000000-create-OrbitMonitoring.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable("orbitMonitoring", {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('orbitMonitoring', {
       id: {
         allowNull: false,
         primaryKey: true,
@@ -11,11 +11,11 @@ module.exports = {
       application_id: {
         type: Sequelize.UUID,
         references: {
-          model: "application",
-          key: "id",
+          model: 'application',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       name: {
         allowNull: false,
@@ -82,8 +82,13 @@ module.exports = {
         type: Sequelize.DATE,
       },
     });
+
+    await queryInterface.addIndex('orbitMonitoring', ['name', 'deletedAt'], {
+      unique: true,
+      name: 'om_unique_name_deleted_at',
+    });
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable("orbitMonitoring");
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('orbitMonitoring');
   },
 };

--- a/Tombolo/server/migrations/20240404150653-create-directorymonitoring.js
+++ b/Tombolo/server/migrations/20240404150653-create-directorymonitoring.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable("directoryMonitoring", {
+    await queryInterface.createTable('directoryMonitoring', {
       id: {
         allowNull: false,
         primaryKey: true,
@@ -11,20 +11,20 @@ module.exports = {
       application_id: {
         type: Sequelize.UUID,
         references: {
-          model: "application",
-          key: "id",
+          model: 'application',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       cluster_id: {
         type: Sequelize.UUID,
         references: {
-          model: "cluster",
-          key: "id",
+          model: 'cluster',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       name: {
         allowNull: false,
@@ -94,10 +94,6 @@ module.exports = {
         allowNull: false,
         type: Sequelize.DataTypes.STRING,
       },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DataTypes.DATE,
-      },
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE,
@@ -111,8 +107,17 @@ module.exports = {
         type: Sequelize.DATE,
       },
     });
+
+    await queryInterface.addIndex(
+      'directoryMonitoring',
+      ['name', 'deletedAt'],
+      {
+        unique: true,
+        name: 'dm_unique_name_deleted_at',
+      }
+    );
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable("directoryMonitoring");
+    await queryInterface.dropTable('directoryMonitoring');
   },
 };

--- a/Tombolo/server/migrations/20250626205533-create-cost-monitoring.js
+++ b/Tombolo/server/migrations/20250626205533-create-cost-monitoring.js
@@ -22,7 +22,6 @@ module.exports = {
       monitoringName: {
         allowNull: false,
         type: Sequelize.STRING,
-        unique: true,
       },
       isActive: {
         allowNull: false,
@@ -98,6 +97,15 @@ module.exports = {
         type: Sequelize.DATE,
       },
     });
+
+    await queryInterface.addIndex(
+      'costMonitoring',
+      ['monitoringName', 'deletedAt'],
+      {
+        unique: true,
+        name: 'cm_unique_monitoring_name_deleted_at',
+      }
+    );
   },
 
   async down(queryInterface, Sequelize) {

--- a/Tombolo/server/migrations/20250630000000-create-landingZoneMonitoring-table.js
+++ b/Tombolo/server/migrations/20250630000000-create-landingZoneMonitoring-table.js
@@ -23,7 +23,6 @@ module.exports = {
       monitoringName: {
         allowNull: false,
         type: Sequelize.STRING,
-        unique: true,
       },
       isActive: {
         allowNull: false,
@@ -111,6 +110,15 @@ module.exports = {
         type: Sequelize.DATE,
       },
     });
+
+    await queryInterface.addIndex(
+      'landingZoneMonitoring',
+      ['monitoringName', 'deletedAt'],
+      {
+        unique: true,
+        name: 'lzm_unique_monitoring_name_deleted_at',
+      }
+    );
   },
   down: async queryInterface => {
     await queryInterface.dropTable('landingZoneMonitoring');

--- a/Tombolo/server/models/clusterMonitoring.js
+++ b/Tombolo/server/models/clusterMonitoring.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 module.exports = (sequelize, DataTypes) => {
   const clusterMonitoring = sequelize.define(
-    "clusterMonitoring",
+    'clusterMonitoring',
     {
       id: {
         primaryKey: true,
@@ -13,7 +13,6 @@ module.exports = (sequelize, DataTypes) => {
       name: {
         allowNull: false,
         type: DataTypes.STRING,
-        unique: true,
       },
       cron: {
         allowNull: true,
@@ -36,17 +35,26 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: true,
       },
     },
-    { paranoid: true, freezeTableName: true }
+    {
+      paranoid: true,
+      freezeTableName: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ['name', 'deletedAt'],
+        },
+      ],
+    }
   );
   clusterMonitoring.associate = function (models) {
     // Define association here
-    clusterMonitoring.belongsTo(models.cluster, { foreignKey: "cluster_id" });
+    clusterMonitoring.belongsTo(models.cluster, { foreignKey: 'cluster_id' });
     clusterMonitoring.belongsTo(models.application, {
-      foreignKey: "application_id",
+      foreignKey: 'application_id',
     });
     clusterMonitoring.hasMany(models.monitoring_notifications, {
-      foreignKey: "application_id",
-      onDelete: "CASCADE",
+      foreignKey: 'application_id',
+      onDelete: 'CASCADE',
     });
   };
   return clusterMonitoring;

--- a/Tombolo/server/models/costMonitoring.js
+++ b/Tombolo/server/models/costMonitoring.js
@@ -22,7 +22,6 @@ module.exports = (sequelize, DataTypes) => {
       monitoringName: {
         allowNull: false,
         type: DataTypes.STRING,
-        unique: true,
       },
       isActive: {
         allowNull: false,
@@ -120,6 +119,12 @@ module.exports = (sequelize, DataTypes) => {
     {
       paranoid: true,
       freezeTableName: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ['monitoringName', 'deletedAt'],
+        },
+      ],
     }
   );
 

--- a/Tombolo/server/models/directoryMonitoring.js
+++ b/Tombolo/server/models/directoryMonitoring.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 module.exports = (sequelize, DataTypes) => {
   const directoryMonitoring = sequelize.define(
-    "directoryMonitoring",
+    'directoryMonitoring',
     {
       id: {
         primaryKey: true,
@@ -21,7 +21,6 @@ module.exports = (sequelize, DataTypes) => {
       name: {
         allowNull: false,
         type: DataTypes.STRING,
-        unique: true,
       },
       description: {
         allowNull: false,
@@ -87,21 +86,28 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         type: DataTypes.DATE,
       },
-      metaData: {
-        type: DataTypes.JSON,
-        allowNull: true,
-      },
     },
-    { paranoid: true, freezeTableName: true }
+    {
+      paranoid: true,
+      freezeTableName: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ['name', 'deletedAt'],
+        },
+      ],
+    }
   );
+
   directoryMonitoring.associate = function (models) {
     // Define association here
     directoryMonitoring.belongsTo(models.application, {
-      foreignKey: "application_id",
+      foreignKey: 'application_id',
     });
     directoryMonitoring.belongsTo(models.cluster, {
-      foreignKey: "cluster_id",
+      foreignKey: 'cluster_id',
     });
   };
+
   return directoryMonitoring;
 };

--- a/Tombolo/server/models/fileMonitoring.js
+++ b/Tombolo/server/models/fileMonitoring.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = (sequelize, DataTypes) => {
   const fileMonitoring = sequelize.define(
-    "fileMonitoring",
+    'fileMonitoring',
     {
       id: {
         primaryKey: true,
@@ -13,7 +13,6 @@ module.exports = (sequelize, DataTypes) => {
       name: {
         allowNull: false,
         type: DataTypes.STRING,
-        unique: true,
       },
       cron: {
         allowNull: true,
@@ -30,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
       wuid: {
         type: DataTypes.STRING,
         allowNull: true,
-        defaultValue: "",
+        defaultValue: '',
       },
       fileTemplateId: {
         type: DataTypes.UUID,
@@ -49,18 +48,29 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: true,
       },
     },
-    { paranoid: true, freezeTableName: true }
+    {
+      paranoid: true,
+      freezeTableName: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ['name', 'deletedAt'],
+        },
+      ],
+    }
   );
-  fileMonitoring.associate = function(models) {
+  fileMonitoring.associate = function (models) {
     // Define association here
-    fileMonitoring.belongsTo(models.fileTemplate, { foreignKey: 'fileTemplateId' });
+    fileMonitoring.belongsTo(models.fileTemplate, {
+      foreignKey: 'fileTemplateId',
+    });
     fileMonitoring.belongsTo(models.cluster, { foreignKey: 'cluster_id' });
     fileMonitoring.belongsTo(models.application, {
-      foreignKey: "application_id",
+      foreignKey: 'application_id',
     });
     fileMonitoring.hasMany(models.monitoring_notifications, {
-      foreignKey: "application_id",
-      onDelete: "CASCADE",
+      foreignKey: 'application_id',
+      onDelete: 'CASCADE',
     });
   };
   return fileMonitoring;

--- a/Tombolo/server/models/filemonitoring_superfile.js
+++ b/Tombolo/server/models/filemonitoring_superfile.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 module.exports = (sequelize, DataTypes) => {
   const fileMonitoring_superfiles = sequelize.define(
-    "filemonitoring_superfiles",
+    'filemonitoring_superfiles',
     {
       id: {
         primaryKey: true,
@@ -33,26 +33,34 @@ module.exports = (sequelize, DataTypes) => {
       name: {
         allowNull: false,
         type: DataTypes.STRING,
-        unique: true,
       },
       metaData: {
         allowNull: true,
         type: DataTypes.JSON,
       },
     },
-    { paranoid: true, freezeTableName: true }
+    {
+      paranoid: true,
+      freezeTableName: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ['name', 'deletedAt'],
+        },
+      ],
+    }
   );
   fileMonitoring_superfiles.associate = function (models) {
     // Define association here
     fileMonitoring_superfiles.belongsTo(models.cluster, {
-      foreignKey: "clusterid",
+      foreignKey: 'clusterid',
     });
     fileMonitoring_superfiles.belongsTo(models.application, {
-      foreignKey: "application_id",
+      foreignKey: 'application_id',
     });
     fileMonitoring_superfiles.hasMany(models.monitoring_notifications, {
-      foreignKey: "application_id",
-      onDelete: "CASCADE",
+      foreignKey: 'application_id',
+      onDelete: 'CASCADE',
     });
   };
   return fileMonitoring_superfiles;

--- a/Tombolo/server/models/jobMonitoring.js
+++ b/Tombolo/server/models/jobMonitoring.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 module.exports = (sequelize, DataTypes) => {
   const JobMonitoring = sequelize.define(
-    "jobMonitoring",
+    'jobMonitoring',
     {
       id: {
         allowNull: false,
@@ -13,16 +13,15 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.UUID,
         allowNull: false,
         references: {
-          model: "application",
-          key: "id",
+          model: 'application',
+          key: 'id',
         },
-        onUpdate: "CASCADE",
-        onDelete: "CASCADE",
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
       },
       monitoringName: {
         allowNull: false,
         type: DataTypes.STRING,
-        unique: true,
       },
       isActive: {
         allowNull: false,
@@ -31,7 +30,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       approvalStatus: {
         allowNull: false,
-        type: DataTypes.ENUM("Approved", "Rejected", "Pending"),
+        type: DataTypes.ENUM('Approved', 'Rejected', 'Pending'),
       },
       approvedBy: {
         allowNull: true,
@@ -93,35 +92,41 @@ module.exports = (sequelize, DataTypes) => {
     {
       paranoid: true,
       freezeTableName: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ['monitoringName', 'deletedAt'],
+        },
+      ],
     }
   );
 
   // Associations
   JobMonitoring.associate = function (models) {
     JobMonitoring.belongsTo(models.application, {
-      foreignKey: "applicationId",
-      onDelete: "CASCADE",
-      onUpdate: "CASCADE",
+      foreignKey: 'applicationId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
     });
 
     JobMonitoring.belongsTo(models.cluster, {
-      foreignKey: "clusterId",
-      onDelete: "NO ACTION",
-      onUpdate: "CASCADE",
+      foreignKey: 'clusterId',
+      onDelete: 'NO ACTION',
+      onUpdate: 'CASCADE',
     });
 
     JobMonitoring.hasMany(models.jobMonitoring_Data, {
-      foreignKey: "monitoringId",
-      as: "jobMonitoringData",
-      onDelete: "CASCADE",
-      onUpdate: "CASCADE",
+      foreignKey: 'monitoringId',
+      as: 'jobMonitoringData',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
     });
 
     JobMonitoring.hasMany(models.jobMonitoring_Data_Archive, {
-      foreignKey: "monitoringId",
-      as: "jobMonitoringDataArchive",
-      onDelete: "CASCADE",
-      onUpdate: "CASCADE",
+      foreignKey: 'monitoringId',
+      as: 'jobMonitoringDataArchive',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
     });
   };
 

--- a/Tombolo/server/models/landingZoneMonitoring.js
+++ b/Tombolo/server/models/landingZoneMonitoring.js
@@ -22,7 +22,6 @@ module.exports = (sequelize, DataTypes) => {
       monitoringName: {
         allowNull: false,
         type: DataTypes.STRING,
-        unique: true,
       },
       isActive: {
         allowNull: false,
@@ -108,6 +107,12 @@ module.exports = (sequelize, DataTypes) => {
     {
       paranoid: true,
       freezeTableName: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ['monitoringName', 'deletedAt'],
+        },
+      ],
     }
   );
 

--- a/Tombolo/server/models/orbitMonitoring.js
+++ b/Tombolo/server/models/orbitMonitoring.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 module.exports = (sequelize, DataTypes) => {
   const orbitMonitoring = sequelize.define(
-    "orbitMonitoring",
+    'orbitMonitoring',
     {
       id: {
         primaryKey: true,
@@ -17,7 +17,6 @@ module.exports = (sequelize, DataTypes) => {
       name: {
         allowNull: false,
         type: DataTypes.STRING,
-        unique: true,
       },
       cron: {
         allowNull: true,
@@ -60,16 +59,25 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: true,
       },
     },
-    { paranoid: true, freezeTableName: true }
+    {
+      paranoid: true,
+      freezeTableName: true,
+      indexes: [
+        {
+          unique: true,
+          fields: ['name', 'deletedAt'],
+        },
+      ],
+    }
   );
   orbitMonitoring.associate = function (models) {
     // Define association here
     orbitMonitoring.belongsTo(models.application, {
-      foreignKey: "application_id",
+      foreignKey: 'application_id',
     });
     orbitMonitoring.hasMany(models.monitoring_notifications, {
-      foreignKey: "application_id",
-      onDelete: "CASCADE",
+      foreignKey: 'application_id',
+      onDelete: 'CASCADE',
     });
   };
   return orbitMonitoring;


### PR DESCRIPTION
## Description

- Removed the unique key from all model and migration objects for `name` or `monitoringName`
- Created a custom unique index for each monitoring table on `name` and `deletedAt` to allow for duplicate names with only one allowed to not be deleted

Fixes #838 

## Developer's Checklist

Please select at least one

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] Breaking change (enhancement, fix, or feature that alters existing functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Vulnerability fix (package updates or CodeQL adjustments to enhance code security)
- [ ] Documentation update (addition or update of documentation or helper text)
- [ ] Other change (please explain in the comment section)

#### Code Quality ( All must be selected )

- [x] I have commented on my code, especially in complex areas
- [x] I have resolved any conflicts with the target branch
- [x] My changes do not generate new warnings
- [x] I have checked my code for any misspellings
- [x] I have ensured my code does not duplicate existing code unnecessarily

#### Documentation

- [x] No documentation changes were required
- [ ] I have made corresponding changes to the documentation

#### Security

- [ ] I have confirmed that all security checks (e.g., CodeQL) have passed
- [x] No user input validation was required for this change
- [ ] All user inputs have appropriate validation, including reasonable character limits

#### UX

- [x] This change does not involve any updates to UX elements
- [ ] Refreshing related pages results in a functional and logical state
- [ ] Appropriate error messages are displayed when necessary

#### Testing

- [x] Existing unit tests pass locally with my changes
- [ ] No new unit tests were necessary for my changes
- [ ] I have added new unit tests for my changes

## Reviewer Checklist

- [ ] I have successfully pulled the branch into my local environment, initiated the project, and verified that all the checked items above have passed
