### PR TITLE
CostMonitoringData rework

### DIFF
--- a/Tombolo/server/jobs/costMonitoring/analyzeCost.js
+++ b/Tombolo/server/jobs/costMonitoring/analyzeCost.js
@@ -259,16 +259,19 @@ async function emailAlreadySent(idempotencyKey) {
   const existingNotification = await SentNotification.findOne({
     where: { idempotencyKey },
   });
-  if (parentPort) {
-    parentPort.postMessage({
-      level: 'info',
-      text: `Cost Monitoring email already sent for idempotencyKey: ${idempotencyKey}`,
-    });
-  } else {
-    logger.info(
-      `Cost Monitoring email already sent for idempotencyKey: ${idempotencyKey}`
-    );
+  if (existingNotification) {
+    if (parentPort) {
+      parentPort.postMessage({
+        level: 'info',
+        text: `Cost Monitoring email already sent for idempotencyKey: ${idempotencyKey}`,
+      });
+    } else {
+      logger.info(
+        `Cost Monitoring email already sent for idempotencyKey: ${idempotencyKey}`
+      );
+    }
   }
+
   return !!existingNotification;
 }
 

--- a/Tombolo/server/jobs/costMonitoring/monitorCost.js
+++ b/Tombolo/server/jobs/costMonitoring/monitorCost.js
@@ -163,221 +163,169 @@ async function monitorCost() {
       return;
     }
 
-    // Get cluster details for each monitoring
+    // 1. Gather all unique cluster IDs referenced by any cost monitoring (or all clusters if any monitoring has clusterIds null/empty)
+    let allClusterIds = new Set();
+    let useAllClusters = false;
     for (const costMonitor of costMonitorings) {
-      const applicationId = costMonitor.applicationId;
-      const clusterIds = costMonitor.clusterIds;
-
-      let clusterDetails;
-      if (clusterIds === null || clusterIds.length === 0) {
-        // Then get all active clusters details
-        const allClusters = await Cluster.findAll({
-          attributes: ['id'],
-          where: { deletedAt: null },
-        });
-        clusterDetails = (
-          await Promise.all(
-            allClusters.map(async cluster => {
-              try {
-                return await getCluster(cluster.id);
-              } catch (err) {
-                parentPort &&
-                  parentPort.postMessage({
-                    level: 'error',
-                    text: `monitorCost: Failed to get cluster ${cluster.name}: ${err.message}, ...skipping`,
-                  });
-              }
-            })
-          )
-        ).filter(Boolean);
-      } else {
-        clusterDetails = (
-          await Promise.all(
-            clusterIds.map(async clusterId => {
-              try {
-                return await getCluster(clusterId);
-              } catch (err) {
-                parentPort &&
-                  parentPort.postMessage({
-                    level: 'error',
-                    text: `monitorCost: Failed to get cluster ${clusterId}: ${err.message}, ...skipping`,
-                  });
-              }
-            })
-          )
-        ).filter(Boolean);
+      if (!costMonitor.clusterIds || costMonitor.clusterIds.length === 0) {
+        useAllClusters = true;
+        break;
       }
+      costMonitor.clusterIds.forEach(id => allClusterIds.add(id));
+    }
 
-      // Iterate clusters
-      for (const clusterDetail of clusterDetails) {
-        try {
-          let newScanTime;
-          // spread timezone offset for each cluster and cluster details
-          const {
-            id: clusterId,
-            thor_host: thorHost,
-            thor_port: thorPort,
-            username,
-            hash,
-            timezone_offset: timezoneOffset,
-            allowSelfSigned,
-          } = clusterDetail;
+    let clusterRecords;
+    if (useAllClusters) {
+      clusterRecords = await Cluster.findAll({
+        attributes: ['id'],
+        where: { deletedAt: null },
+      });
+      allClusterIds = new Set(clusterRecords.map(c => c.id));
+    } else {
+      clusterRecords = await Cluster.findAll({
+        attributes: ['id'],
+        where: { id: Array.from(allClusterIds), deletedAt: null },
+      });
+    }
 
-          // Check if a monitoring log exists
-          const monitoringLog = await MonitoringLog.findOne({
-            where: {
-              cluster_id: clusterId,
-              monitoring_type_id: monitoringType.id,
-            },
-          });
+    // 2. For each cluster, aggregate all cost monitoring data into a single CostMonitoringData row
+    for (const clusterRecord of clusterRecords) {
+      const clusterId = clusterRecord.id;
+      try {
+        const clusterDetail = await getCluster(clusterId);
+        const {
+          thor_host: thorHost,
+          thor_port: thorPort,
+          username,
+          hash,
+          timezone_offset: timezoneOffset,
+          allowSelfSigned,
+        } = clusterDetail;
 
-          // Get start and end date
-          const { endTime: endDate, startTime: startDate } = getStartAndEndTime(
-            monitoringLog ? monitoringLog.scan_time : null,
-            timezoneOffset,
-            true
-          );
+        // Check if a monitoring log exists
+        const monitoringLog = await MonitoringLog.findOne({
+          where: {
+            cluster_id: clusterId,
+            monitoring_type_id: monitoringType.id,
+          },
+        });
 
-          // Get costMonitoringData
-          const costMonitoringData = {
-            monitoringId: costMonitor.id,
-            applicationId,
-            date: new Date(),
-            clusterId,
-            usersCostInfo: {},
-            metaData: {},
-            analyzed: false,
-          };
+        // Get start and end date
+        const { endTime: endDate, startTime: startDate } = getStartAndEndTime(
+          monitoringLog ? monitoringLog.scan_time : null,
+          timezoneOffset,
+          true
+        );
 
-          // Get cluster options
-          const clusterOptions = getClusterOptions(
-            {
-              baseUrl: `${thorHost}:${thorPort}`,
-              userID: username || '',
-              password: hash || '',
-              timeoutSecs: 180,
-            },
-            allowSelfSigned
-          );
+        // Get cluster options
+        const clusterOptions = getClusterOptions(
+          {
+            baseUrl: `${thorHost}:${thorPort}`,
+            userID: username || '',
+            password: hash || '',
+            timeoutSecs: 180,
+          },
+          allowSelfSigned
+        );
 
-          // Set the new scanTime
-          newScanTime = new Date();
+        // Set the new scanTime
+        const newScanTime = new Date();
 
-          // Get work Units for the last hour where their state is terminal
+        // Query for workunits during timeframe
+        const response = await Workunit.query(clusterOptions, {
+          StartDate: startDate,
+          EndDate: endDate,
+          PageSize: 99999, // Ensure we get all workunits
+        });
 
-          // Query for workunits during timeframe
-          const response = await Workunit.query(clusterOptions, {
-            StartDate: startDate,
-            EndDate: endDate,
-            PageSize: 99999, // Ensure we get all workunits
-          });
+        const terminalWorkUnits =
+          response.filter(
+            workUnit =>
+              workUnit.State === 'failed' || workUnit.State === 'completed'
+          ) || [];
 
-          const terminalWorkUnits =
-            response.filter(
-              workUnit =>
-                workUnit.State === 'failed' || workUnit.State === 'completed'
-            ) || [];
+        // Aggregate cost data for this cluster
+        const usersCostInfo = {};
+        const metaData = {
+          wuCostData: {},
+          clusterCostData: {
+            compileCost: 0,
+            executeCost: 0,
+            fileAccessCost: 0,
+            totalCost: 0,
+          },
+        };
 
-          // Iterate work Units
-          terminalWorkUnits.forEach(
-            ({
-              Owner,
-              CompileCost,
-              FileAccessCost,
-              ExecuteCost,
-              Wuid,
-              Jobname,
-            }) => {
-              // Ensure the costs are a number and not null/undefined
-              CompileCost = CompileCost ?? 0;
-              FileAccessCost = FileAccessCost ?? 0;
-              ExecuteCost = ExecuteCost ?? 0;
+        terminalWorkUnits.forEach(
+          ({
+            Owner,
+            CompileCost,
+            FileAccessCost,
+            ExecuteCost,
+            Wuid,
+            Jobname,
+          }) => {
+            // Ensure the costs are a number and not null/undefined
+            CompileCost = CompileCost ?? 0;
+            FileAccessCost = FileAccessCost ?? 0;
+            ExecuteCost = ExecuteCost ?? 0;
 
-              // Ensure expected fields are present in costMonitoringData for JSON fields
-              if (!costMonitoringData.hasOwnProperty('metaData'))
-                costMonitoringData.metaData = {};
-              if (!costMonitoringData.metaData.hasOwnProperty('wuCostData'))
-                costMonitoringData.metaData.wuCostData = {};
-              if (!costMonitoringData.metaData.wuCostData.hasOwnProperty(Wuid))
-                costMonitoringData.metaData.wuCostData[Wuid] = {
-                  jobName: '',
-                  owner: '',
-                  compileCost: 0,
-                  executeCost: 0,
-                  fileAccessCost: 0,
-                  totalCost: 0,
-                };
-              if (!costMonitoringData.usersCostInfo.hasOwnProperty(Owner))
-                costMonitoringData.usersCostInfo[Owner] = {
-                  compileCost: 0,
-                  executeCost: 0,
-                  fileAccessCost: 0,
-                  totalCost: 0,
-                };
-
-              if (
-                !costMonitoringData.metaData.hasOwnProperty('clusterCostData')
-              )
-                costMonitoringData.metaData.clusterCostData = {
-                  compileCost: 0,
-                  executeCost: 0,
-                  fileAccessCost: 0,
-                  totalCost: 0,
-                };
-
-              const totalCost = CompileCost + ExecuteCost + FileAccessCost;
-
-              // Set clusterCostData to aggregate cost for all workunits
-              costMonitoringData.metaData.clusterCostData.fileAccessCost +=
-                FileAccessCost;
-              costMonitoringData.metaData.clusterCostData.compileCost +=
-                CompileCost;
-              costMonitoringData.metaData.clusterCostData.executeCost +=
-                ExecuteCost;
-              costMonitoringData.metaData.clusterCostData.totalCost +=
-                totalCost;
-
-              // Set wuCostData for specific workunit
-              costMonitoringData.metaData.wuCostData[Wuid].jobName = Jobname;
-              costMonitoringData.metaData.wuCostData[Wuid].owner = Owner;
-              costMonitoringData.metaData.wuCostData[Wuid].compileCost =
-                CompileCost;
-              costMonitoringData.metaData.wuCostData[Wuid].executeCost =
-                ExecuteCost;
-              costMonitoringData.metaData.wuCostData[Wuid].fileAccessCost =
-                FileAccessCost;
-              costMonitoringData.metaData.wuCostData[Wuid].totalCost =
-                totalCost;
-
-              // Set userCostInfo for a specific user
-              costMonitoringData.usersCostInfo[Owner].compileCost +=
-                CompileCost;
-              costMonitoringData.usersCostInfo[Owner].executeCost +=
-                ExecuteCost;
-              costMonitoringData.usersCostInfo[Owner].fileAccessCost +=
-                FileAccessCost;
-              costMonitoringData.usersCostInfo[Owner].totalCost += totalCost;
+            if (!metaData.wuCostData[Wuid]) {
+              metaData.wuCostData[Wuid] = {
+                jobName: Jobname,
+                owner: Owner,
+                compileCost: CompileCost,
+                executeCost: ExecuteCost,
+                fileAccessCost: FileAccessCost,
+                totalCost: CompileCost + ExecuteCost + FileAccessCost,
+              };
             }
-          );
 
-          // Save costMonitoringData on each iteration
-          await CostMonitoringData.create(costMonitoringData);
+            if (!usersCostInfo[Owner]) {
+              usersCostInfo[Owner] = {
+                compileCost: 0,
+                executeCost: 0,
+                fileAccessCost: 0,
+                totalCost: 0,
+              };
+            }
 
-          // If monitoring log doesn't exist create it. If it does update scan time
-          await handleMonitorLogs(
-            monitoringLog,
-            clusterId,
-            monitoringType.id,
-            newScanTime
-          );
-        } catch (perClusterError) {
-          logger.error('>>> monitorCost: Error in cluster ', perClusterError);
-          parentPort &&
-            parentPort.postMessage({
-              level: 'error',
-              text: `monitorCost: Failed in cluster ${clusterDetail.name}: ${perClusterError.message}, ...skipping`,
-            });
-        }
+            usersCostInfo[Owner].compileCost += CompileCost;
+            usersCostInfo[Owner].executeCost += ExecuteCost;
+            usersCostInfo[Owner].fileAccessCost += FileAccessCost;
+            usersCostInfo[Owner].totalCost +=
+              CompileCost + ExecuteCost + FileAccessCost;
+
+            metaData.clusterCostData.compileCost += CompileCost;
+            metaData.clusterCostData.executeCost += ExecuteCost;
+            metaData.clusterCostData.fileAccessCost += FileAccessCost;
+            metaData.clusterCostData.totalCost +=
+              CompileCost + ExecuteCost + FileAccessCost;
+          }
+        );
+
+        // Save a single CostMonitoringData row per cluster
+        await CostMonitoringData.create({
+          date: new Date(),
+          clusterId,
+          usersCostInfo,
+          metaData,
+        });
+
+        // If monitoring log doesn't exist create it. If it does update scan time
+        await handleMonitorLogs(
+          monitoringLog,
+          clusterId,
+          monitoringType.id,
+          newScanTime
+        );
+      } catch (perClusterError) {
+        logger.error('>>> monitorCost: Error in cluster ', perClusterError);
+        parentPort &&
+          parentPort.postMessage({
+            level: 'error',
+            text: `monitorCost: Failed in cluster ${clusterRecord.name || clusterId}: ${perClusterError.message}, ...skipping`,
+          });
       }
     }
     parentPort &&

--- a/Tombolo/server/migrations/20250626205841-create-cost-monitoring-data.js
+++ b/Tombolo/server/migrations/20250626205841-create-cost-monitoring-data.js
@@ -10,26 +10,6 @@ module.exports = {
         type: Sequelize.UUID,
         defaultValue: Sequelize.UUIDV4,
       },
-      applicationId: {
-        type: Sequelize.UUID,
-        allowNull: false,
-        references: {
-          model: 'applications',
-          key: 'id',
-        },
-        onUpdate: 'CASCADE',
-        onDelete: 'CASCADE',
-      },
-      monitoringId: {
-        type: Sequelize.UUID,
-        allowNull: false,
-        references: {
-          model: 'cost_monitorings',
-          key: 'id',
-        },
-        onUpdate: 'CASCADE',
-        onDelete: 'CASCADE',
-      },
       clusterId: {
         type: Sequelize.UUID,
         allowNull: false,
@@ -65,12 +45,6 @@ module.exports = {
         type: Sequelize.DATE,
       },
     });
-
-    // await queryInterface.addIndex('cost_monitoring_data', {
-    //   unique: true,
-    //   fields: ['monitoringId', 'applicationId', 'clusterId', 'analyzed'],
-    //   name: 'costMonitoringData_unique_monitoring_app_cluster_analyzed',
-    // });
   },
 
   async down(queryInterface, Sequelize) {

--- a/Tombolo/server/migrations/20250714152857-create-cost-monitoring-data-archive.js
+++ b/Tombolo/server/migrations/20250714152857-create-cost-monitoring-data-archive.js
@@ -10,31 +10,11 @@ module.exports = {
         type: Sequelize.UUID,
         defaultValue: Sequelize.UUIDV4,
       },
-      applicationId: {
-        type: Sequelize.UUID,
-        allowNull: false,
-        references: {
-          model: 'applications',
-          key: 'id',
-        },
-        onUpdate: 'CASCADE',
-        onDelete: 'CASCADE',
-      },
       clusterId: {
         type: Sequelize.UUID,
         allowNull: false,
         references: {
           model: 'clusters',
-          key: 'id',
-        },
-        onUpdate: 'CASCADE',
-        onDelete: 'CASCADE',
-      },
-      monitoringId: {
-        type: Sequelize.UUID,
-        allowNull: false,
-        references: {
-          model: 'cost_monitorings',
           key: 'id',
         },
         onUpdate: 'CASCADE',
@@ -47,11 +27,6 @@ module.exports = {
       usersCostInfo: {
         allowNull: false,
         type: Sequelize.JSON,
-      },
-      analyzed: {
-        allowNull: false,
-        type: Sequelize.BOOLEAN,
-        defaultValue: false,
       },
       metaData: {
         allowNull: true,
@@ -83,21 +58,9 @@ module.exports = {
       'archivedAt',
     ]);
     await queryInterface.addIndex('cost_monitoring_data_archive', [
-      'monitoringId',
-    ]);
-    await queryInterface.addIndex('cost_monitoring_data_archive', [
-      'applicationId',
-    ]);
-    await queryInterface.addIndex('cost_monitoring_data_archive', [
       'clusterId',
     ]);
     await queryInterface.addIndex('cost_monitoring_data_archive', ['date']);
-
-    // Composite index for common queries
-    await queryInterface.addIndex('cost_monitoring_data_archive', {
-      fields: ['monitoringId', 'applicationId', 'clusterId'],
-      name: 'idx_cost_monitoring_data_archive_composite',
-    });
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/Tombolo/server/services/costMonitoringDataArchiveService.js
+++ b/Tombolo/server/services/costMonitoringDataArchiveService.js
@@ -15,7 +15,6 @@ class CostMonitoringDataArchiveService extends ArchiveService {
     try {
       const archivedCount = await this.archiveRecords(this.modelName, {
         date: { [Op.lt]: cutoffDate },
-        analyzed: true,
       });
 
       logger.info(


### PR DESCRIPTION
## Description

- Removed applicationId and monitoringId from the `CostMonitoringData` model
- Updated `getClusterDataTotals` and `getDataTotals` to retrieve data based on `clusterId` instead of `monitoringId`
- Updated the monitorCost job to interact with CostMonitoringData correctly based on the new model definition.
- Removed references to the `analyzed` column as it no longer exists
- Fixed a bug where every execution of `analyzeCost.js` would log that an email was already sent for the idempotencyKey

Fixes #1341 

## Developer's Checklist

Please select at least one

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] Breaking change (enhancement, fix, or feature that alters existing functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Vulnerability fix (package updates or CodeQL adjustments to enhance code security)
- [ ] Documentation update (addition or update of documentation or helper text)
- [ ] Other change (please explain in the comment section)

#### Code Quality ( All must be selected )

- [x] I have commented on my code, especially in complex areas
- [x] I have resolved any conflicts with the target branch
- [x] My changes do not generate new warnings
- [x] I have checked my code for any misspellings
- [x] I have ensured my code does not duplicate existing code unnecessarily

#### Documentation

- [x] No documentation changes were required
- [ ] I have made corresponding changes to the documentation

#### Security

- [ ] I have confirmed that all security checks (e.g., CodeQL) have passed
- [x] No user input validation was required for this change
- [ ] All user inputs have appropriate validation, including reasonable character limits

#### UX

- [x] This change does not involve any updates to UX elements
- [ ] Refreshing related pages results in a functional and logical state
- [ ] Appropriate error messages are displayed when necessary

#### Testing

- [x] Existing unit tests pass locally with my changes
- [ ] No new unit tests were necessary for my changes
- [ ] I have added new unit tests for my changes

## Reviewer Checklist

- [ ] I have successfully pulled the branch into my local environment, initiated the project, and verified that all the checked items above have passed
