### PR TITLE
CostMonitoringData archive fixes

### DIFF
--- a/Tombolo/server/migrations/20250714152857-create-cost-monitoring-data-archive.js
+++ b/Tombolo/server/migrations/20250714152857-create-cost-monitoring-data-archive.js
@@ -24,6 +24,10 @@ module.exports = {
         allowNull: false,
         type: Sequelize.DATE,
       },
+      localDay: {
+        type: Sequelize.DATEONLY,
+        comment: 'Precomputed local day for fast queries',
+      },
       usersCostInfo: {
         allowNull: false,
         type: Sequelize.JSON,
@@ -53,12 +57,18 @@ module.exports = {
       },
     });
 
+    // Composite index for fast queries by cluster, local_day, and deletedAt (matches source table)
+    await queryInterface.addIndex(
+      'cost_monitoring_data_archive',
+      ['clusterId', 'localDay', 'deletedAt'],
+      {
+        name: 'idx_cmd_archive_cluster_localday_notdeleted',
+      }
+    );
+
     // Add indexes for better query performance
     await queryInterface.addIndex('cost_monitoring_data_archive', [
       'archivedAt',
-    ]);
-    await queryInterface.addIndex('cost_monitoring_data_archive', [
-      'clusterId',
     ]);
     await queryInterface.addIndex('cost_monitoring_data_archive', ['date']);
   },

--- a/Tombolo/server/models/CostMonitoring.js
+++ b/Tombolo/server/models/CostMonitoring.js
@@ -12,12 +12,9 @@ module.exports = (sequelize, DataTypes) => {
         onUpdate: 'CASCADE',
       });
 
-      CostMonitoring.hasMany(models.CostMonitoringData, {
-        foreignKey: 'monitoringId',
-        as: 'costMonitoringData',
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE',
-      });
+      // NOTE: CostMonitoringData is no longer directly related to CostMonitoring
+      // Cost data is now cluster-based and can be used by multiple monitorings
+      // See CostMonitoringData model for cluster-based relationship
 
       CostMonitoring.belongsTo(models.User, {
         foreignKey: 'createdBy',

--- a/Tombolo/server/services/costMonitoringDataArchiveService.js
+++ b/Tombolo/server/services/costMonitoringDataArchiveService.js
@@ -62,9 +62,9 @@ class CostMonitoringDataArchiveService extends ArchiveService {
         [
           this.sequelize.fn(
             'COUNT',
-            this.sequelize.fn('DISTINCT', this.sequelize.col('applicationId'))
+            this.sequelize.fn('DISTINCT', this.sequelize.col('clusterId'))
           ),
-          'uniqueApplications',
+          'uniqueClusters',
         ],
       ],
       raw: true,
@@ -89,6 +89,77 @@ class CostMonitoringDataArchiveService extends ArchiveService {
       `Cleaned up ${deletedCount} archived records older than ${archiveRetentionDays} days`
     );
     return deletedCount;
+  }
+
+  /**
+   * Get archived cost data for a specific cluster
+   * @param {string} clusterId - UUID of the cluster
+   * @param {Object} additionalFilters - Additional filter criteria
+   * @returns {Promise<Array>} Archived records for the cluster
+   */
+  async getArchivedDataByCluster(clusterId, additionalFilters = {}) {
+    return await this.getCostDataArchive({
+      clusterId,
+      ...additionalFilters,
+    });
+  }
+
+  /**
+   * Archive cost data for a specific cluster older than the specified days
+   * @param {string} clusterId - UUID of the cluster
+   * @param {number} daysToKeep - Number of days to keep before archiving
+   * @returns {Promise<number>} Number of records archived
+   */
+  async archiveOldCostDataByCluster(clusterId, daysToKeep = 30) {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - daysToKeep);
+
+    try {
+      const archivedCount = await this.archiveRecords(this.modelName, {
+        clusterId,
+        date: { [Op.lt]: cutoffDate },
+      });
+
+      logger.info(
+        `Archived ${archivedCount} cost monitoring records for cluster ${clusterId} older than ${daysToKeep} days`
+      );
+      return archivedCount;
+    } catch (error) {
+      logger.error(
+        `Failed to archive cost monitoring data for cluster ${clusterId}:`,
+        error
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Get archive statistics grouped by cluster
+   * @returns {Promise<Array>} Statistics per cluster including record counts and date ranges
+   */
+  async getArchiveStatsByCluster() {
+    const ArchiveModel = await this.getArchiveModel(this.modelName);
+
+    const stats = await ArchiveModel.findAll({
+      attributes: [
+        'clusterId',
+        [this.sequelize.fn('COUNT', this.sequelize.col('id')), 'recordCount'],
+        [this.sequelize.fn('MIN', this.sequelize.col('date')), 'oldestRecord'],
+        [this.sequelize.fn('MAX', this.sequelize.col('date')), 'newestRecord'],
+        [
+          this.sequelize.fn('MIN', this.sequelize.col('archivedAt')),
+          'firstArchivedAt',
+        ],
+        [
+          this.sequelize.fn('MAX', this.sequelize.col('archivedAt')),
+          'lastArchivedAt',
+        ],
+      ],
+      group: ['clusterId'],
+      raw: true,
+    });
+
+    return stats;
   }
 }
 

--- a/Tombolo/server/utils/archiveUtils.js
+++ b/Tombolo/server/utils/archiveUtils.js
@@ -23,8 +23,10 @@ class ArchiveManager {
   }
 
   createArchiveModel(originalModel, archiveModelName) {
+    // Use getAttributes() which returns current attributes, not cached rawAttributes
     const attributes = { ...originalModel.getAttributes() };
 
+    // Add archivedAt field for tracking when records were archived
     attributes.archivedAt = {
       type: DataTypes.DATE,
       allowNull: false,
@@ -32,7 +34,7 @@ class ArchiveManager {
     };
 
     return this.sequelize.define(archiveModelName, attributes, {
-      tableName: `${originalModel.tableName}Archive`,
+      tableName: `${originalModel.tableName}_archive`,
       timestamps: true,
       paranoid: true,
     });


### PR DESCRIPTION
## Description

- Updated cost monitoring data archive to match schema of cost monitoring data
- Fixed a few bugs with caching of the model
- Removed the CostMonitoring relationship to CostMonitoringData (based on monitoringId which doesn't exist in table anymore)

Fixes #1412 

## Developer's Checklist

Please select at least one

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] Breaking change (enhancement, fix, or feature that alters existing functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Vulnerability fix (package updates or CodeQL adjustments to enhance code security)
- [ ] Documentation update (addition or update of documentation or helper text)
- [ ] Other change (please explain in the comment section)

#### Code Quality ( All must be selected )

- [x] I have commented on my code, especially in complex areas
- [x] I have resolved any conflicts with the target branch
- [x] My changes do not generate new warnings
- [x] I have checked my code for any misspellings
- [x] I have ensured my code does not duplicate existing code unnecessarily

#### Documentation

- [x] No documentation changes were required
- [ ] I have made corresponding changes to the documentation

#### Security

- [ ] I have confirmed that all security checks (e.g., CodeQL) have passed
- [x] No user input validation was required for this change
- [ ] All user inputs have appropriate validation, including reasonable character limits

#### UX

- [x] This change does not involve any updates to UX elements
- [ ] Refreshing related pages results in a functional and logical state
- [ ] Appropriate error messages are displayed when necessary

#### Testing

- [x] Existing unit tests pass locally with my changes
- [ ] No new unit tests were necessary for my changes
- [ ] I have added new unit tests for my changes

## Reviewer Checklist

- [ ] I have successfully pulled the branch into my local environment, initiated the project, and verified that all the checked items above have passed
