### PR TITLE
docs(job-monitoring): add time series analysis description and metrics

### DIFF
--- a/tombolo_docs/docs/User-Guides/monitoring/jobMonitoring.md
+++ b/tombolo_docs/docs/User-Guides/monitoring/jobMonitoring.md
@@ -18,7 +18,7 @@ Tombolo allows you to monitor various states of a work unit to ensure jobs run a
 
 **Unknown** When a work unit enters an unknown state, Tombolo will notify you to investigate further.
 
----
+**Time Series Analysis** Tombolo also performs a time-series analysis on nine job metrics to detect deviations from normal behavior. The analyzed data points are: `WarningCount`, `ErrorCount`, `GraphCount`, `SourceFileCount`, `ResultCount`, `TotalClusterTime`, `FileAccessCost`, `CompileCost`, and `ExecuteCost`. For each run Tombolo compares the current value against the recent history (up to 10 previous runs), computing mean, standard deviation, z-score, and an expected range (mean ± 3·std). If a metric falls outside the expected range Tombolo flags it and generates a Time Series Analysis alert with historical values and context.
 
 <div class="custom_details_component">
 <details class="env_config-details">


### PR DESCRIPTION
## Description

Please provide a summary of the changes made and the issue it resolves. Include relevant context and any dependencies required for this change.

Fixes # (issue)

## Developer's Checklist

Please select at least one

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] Breaking change (enhancement, fix, or feature that alters existing functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Vulnerability fix (package updates or CodeQL adjustments to enhance code security)
- [ ] Documentation update (addition or update of documentation or helper text)
- [x] Other change (please explain in the comment section)

#### Code Quality ( All must be selected )

- [x] I have commented on my code, especially in complex areas
- [x] I have resolved any conflicts with the target branch
- [x] My changes do not generate new warnings
- [x] I have checked my code for any misspellings
- [ ] I have ensured my code does not duplicate existing code unnecessarily

#### Documentation

- [ ] No documentation changes were required
- [x] I have made corresponding changes to the documentation

#### Security

- [x] I have confirmed that all security checks (e.g., CodeQL) have passed
- [x] No user input validation was required for this change
- [ ] All user inputs have appropriate validation, including reasonable character limits

#### UX

- [ ] This change does not involve any updates to UX elements
- [x] Refreshing related pages results in a functional and logical state
- [ ] Appropriate error messages are displayed when necessary

#### Testing

- [x] Existing unit tests pass locally with my changes
- [x] No new unit tests were necessary for my changes
- [ ] I have added new unit tests for my changes

## Reviewer Checklist

- [ ] I have successfully pulled the branch into my local environment, initiated the project, and verified that all the checked items above have passed
