### PR TITLE
Type errors in OverviewPanel

### DIFF
--- a/Tombolo/client-reactjs/src/components/admin/workunits/history/details/WorkUnitView.tsx
+++ b/Tombolo/client-reactjs/src/components/admin/workunits/history/details/WorkUnitView.tsx
@@ -19,6 +19,7 @@ import SqlPanel from './panels/SqlPanel';
 import HistoryPanel from './panels/HistoryPanel';
 import styles from '../workunitHistory.module.css';
 import { getRoleNameArray } from '@/components/common/AuthUtil';
+import type { WorkUnit } from '@tombolo/shared';
 
 dayjs.extend(duration);
 
@@ -26,7 +27,7 @@ const { Title, Text } = Typography;
 const { TabPane } = Tabs as any;
 
 interface Props {
-  wu: any;
+  wu: WorkUnit;
   details: any[];
   clusterName?: string;
   onRefresh?: () => void;

--- a/Tombolo/client-reactjs/src/components/admin/workunits/history/details/index.tsx
+++ b/Tombolo/client-reactjs/src/components/admin/workunits/history/details/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { Spin, Button, message, Alert, Space } from 'antd';
 import { ArrowLeftOutlined, ReloadOutlined } from '@ant-design/icons';
 import workunitsService from '@/services/workunits.service';
+import type { WorkUnit } from '@tombolo/shared';
 import WorkUnitView from './WorkUnitView';
 import styles from '../workunitHistory.module.css';
 
@@ -19,7 +20,7 @@ const WorkUnitDetails: React.FC = () => {
   }, [clusters, clusterId]);
 
   const [loading, setLoading] = useState<boolean>(true);
-  const [wu, setWu] = useState<any>(null);
+  const [wu, setWu] = useState<WorkUnit | null>(null);
   const [details, setDetails] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
 

--- a/Tombolo/client-reactjs/src/components/admin/workunits/history/details/panels/OverviewPanel.tsx
+++ b/Tombolo/client-reactjs/src/components/admin/workunits/history/details/panels/OverviewPanel.tsx
@@ -38,6 +38,7 @@ import HierarchyExplorer, {
   findPathByKey,
   flattenTree,
 } from './HierarchyExplorer';
+import type { WorkUnit } from '@tombolo/shared';
 
 const { Text } = Typography;
 
@@ -46,23 +47,11 @@ function renderAnyMetric(key: string, value: any): React.ReactNode {
   return renderAnyMetricShared(key, value);
 }
 
-// ── Types ────────────────────────────────────────────────────────────────────
-
 interface Props {
-  wu: {
-    jobName?: string;
-    wuId?: string;
-    state?: string;
-    engine?: string;
-    clusterId?: string;
-    owner?: string;
-    totalClusterTime?: number;
-  };
+  wu: WorkUnit;
   details: any[];
   clusterName?: string;
 }
-
-// ── Component ────────────────────────────────────────────────────────────────
 
 const OverviewPanel: React.FC<Props> = ({ wu, details, clusterName }) => {
   const [selectedNode, setSelectedNode] = useState<any>(null);

--- a/Tombolo/client-reactjs/src/services/workunits.service.ts
+++ b/Tombolo/client-reactjs/src/services/workunits.service.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/services/api';
+import type { WorkUnit, WorkUnitDetailsResponse } from '@tombolo/shared';
 
 const workunitsService = {
   getAll: async (params: Record<string, any> = {}): Promise<any> => {
@@ -6,12 +7,12 @@ const workunitsService = {
     return response.data;
   },
 
-  getById: async (clusterId: string, wuid: string): Promise<any> => {
+  getById: async (clusterId: string, wuid: string): Promise<WorkUnit> => {
     const response = await apiClient.get(`/workunits/${clusterId}/${wuid}`);
     return response.data;
   },
 
-  getDetails: async (clusterId: string, wuid: string): Promise<any> => {
+  getDetails: async (clusterId: string, wuid: string): Promise<WorkUnitDetailsResponse> => {
     const response = await apiClient.get(`/workunits/${clusterId}/${wuid}/details`);
     return response.data;
   },
@@ -57,7 +58,11 @@ const workunitsService = {
   },
 
   // Paging & lazy fetch helpers for scopes (virtualization support)
-  getScopes: async (clusterId: string, wuid: string, options: { limit?: number; cursor?: number } = {}): Promise<any> => {
+  getScopes: async (
+    clusterId: string,
+    wuid: string,
+    options: { limit?: number; cursor?: number } = {}
+  ): Promise<any> => {
     const response = await apiClient.get(`/workunits/${clusterId}/${wuid}/scopes`, { params: options });
     return response.data;
   },
@@ -68,7 +73,9 @@ const workunitsService = {
   },
 
   getScopeHistory: async (clusterId: string, wuid: string, scopeId: string): Promise<any> => {
-    const response = await apiClient.get(`/workunits/${clusterId}/${wuid}/scopes/${encodeURIComponent(scopeId)}/history`);
+    const response = await apiClient.get(
+      `/workunits/${clusterId}/${wuid}/scopes/${encodeURIComponent(scopeId)}/history`
+    );
     return response.data;
   },
 };

--- a/Tombolo/server/controllers/workunitController.ts
+++ b/Tombolo/server/controllers/workunitController.ts
@@ -7,6 +7,7 @@ import logger from '../config/logger.js';
 import { getCluster } from '../utils/hpcc-util.js';
 import { getClusterOptions } from '../utils/getClusterOptions.js';
 import { findFuzzyMatches } from '@tombolo/shared';
+import type { WorkUnitDetailsResponse } from '@tombolo/shared';
 
 type ScopeNode = InferAttributes<WorkUnitDetails> & { children: ScopeNode[] };
 
@@ -190,9 +191,9 @@ async function getWorkunitDetails(req: Request, res: Response) {
     return sendSuccess(res, {
       wuId: wuid,
       clusterId,
-      fetchedAt: details[0].createdAt || new Date(),
+      fetchedAt: (details[0].createdAt || new Date()).toISOString(),
       graphs,
-    });
+    } satisfies WorkUnitDetailsResponse);
   } catch (err) {
     logger.error('Get workunit details error: ', err);
     return sendError(res, 'Failed to fetch details', 500);

--- a/Tombolo/server/controllers/workunitController.ts
+++ b/Tombolo/server/controllers/workunitController.ts
@@ -188,10 +188,19 @@ async function getWorkunitDetails(req: Request, res: Response) {
 
     const graphs = buildScopeHierarchy(details);
 
+    const rawCreatedAt = details[0].createdAt;
+    const normalizedCreatedAt =
+      rawCreatedAt instanceof Date
+        ? rawCreatedAt
+        : new Date(rawCreatedAt ?? Date.now());
+    const fetchedAt = Number.isNaN(normalizedCreatedAt.getTime())
+      ? new Date().toISOString()
+      : normalizedCreatedAt.toISOString();
+
     return sendSuccess(res, {
       wuId: wuid,
       clusterId,
-      fetchedAt: (details[0].createdAt || new Date()).toISOString(),
+      fetchedAt,
       graphs,
     } satisfies WorkUnitDetailsResponse);
   } catch (err) {

--- a/Tombolo/shared/src/types/index.ts
+++ b/Tombolo/shared/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './role.js';
 export * from './asr.js';
 export * from './notification.js';
 export * from './integration.js';
+export * from './workunit.js';

--- a/Tombolo/shared/src/types/workunit.ts
+++ b/Tombolo/shared/src/types/workunit.ts
@@ -24,5 +24,14 @@ export interface WorkUnitDetailsResponse {
   wuId: string;
   clusterId: string;
   fetchedAt: string;
-  graphs: unknown[];
+  graphs: WorkUnitGraph[];
+}
+
+export interface WorkUnitGraph {
+  id?: string | number;
+  scopeId?: string | null;
+  scopeName?: string;
+  scopeType?: string;
+  children?: WorkUnitGraph[];
+  [key: string]: unknown;
 }

--- a/Tombolo/shared/src/types/workunit.ts
+++ b/Tombolo/shared/src/types/workunit.ts
@@ -1,0 +1,28 @@
+export interface WorkUnit {
+  wuId: string;
+  clusterId: string;
+  workUnitTimestamp: string;
+  owner: string;
+  engine: string;
+  state: string;
+  totalClusterTime: number;
+  totalCost: number;
+  jobName?: string | null;
+  actionEx?: string | null;
+  executeCost?: number;
+  fileAccessCost?: number;
+  compileCost?: number;
+  endTimestamp?: string | null;
+  savingPotential?: number | null;
+  detailsFetchedAt?: string | null;
+  infoFetchedAt?: string | null;
+  clusterDeleted?: boolean;
+  hasDetails?: boolean;
+}
+
+export interface WorkUnitDetailsResponse {
+  wuId: string;
+  clusterId: string;
+  fetchedAt: string;
+  graphs: unknown[];
+}


### PR DESCRIPTION
Replace the narrow inline wu prop type in OverviewPanel (missing workUnitTimestamp and totalCost) with the shared WorkUnit interface. Propagate the type through workunits.service, details/index, and WorkUnitView. Also type the workunitController getWorkunitDetails response with satisfies WorkUnitDetailsResponse to keep server and client contracts in sync.

Fixes # 1860

## Developer's Checklist

Please select at least one

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] Breaking change (enhancement, fix, or feature that alters existing functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Vulnerability fix (package updates or CodeQL adjustments to enhance code security)
- [ ] Documentation update (addition or update of documentation or helper text)
- [ ] Other change (please explain in the comment section)

#### Code Quality ( All must be selected )

- [x] I have commented on my code, especially in complex areas
- [x] I have resolved any conflicts with the target branch
- [x] My changes do not generate new warnings
- [x] I have checked my code for any misspellings
- [ ] I have ensured my code does not duplicate existing code unnecessarily

#### Documentation

- [x] No documentation changes were required
- [ ] I have made corresponding changes to the documentation

#### Security

- [x] I have confirmed that all security checks (e.g., CodeQL) have passed
- [ ] No user input validation was required for this change
- [ ] All user inputs have appropriate validation, including reasonable character limits

#### UX

- [x] This change does not involve any updates to UX elements
- [ ] Refreshing related pages results in a functional and logical state
- [ ] Appropriate error messages are displayed when necessary

#### Testing

- [x] Existing unit tests pass locally with my changes
- [ ] No new unit tests were necessary for my changes
- [ ] I have added new unit tests for my changes

## Reviewer Checklist

- [x] I have successfully pulled the branch into my local environment, initiated the project, and verified that all the checked items above have passed
