### PR TITLE
Dashboard Highlights failed workunits and improves job grouping

### DIFF
--- a/Tombolo/client-reactjs/src/components/admin/workunits/dashboard/Dashboard.module.css
+++ b/Tombolo/client-reactjs/src/components/admin/workunits/dashboard/Dashboard.module.css
@@ -204,3 +204,11 @@
 .legendSwatchCompile {
   background: #d97706;
 }
+
+:global(.dashboard-wu-row-failed) {
+  background-color: #ffe5e5 !important;
+}
+
+:global(.dashboard-wu-row-failed:hover) {
+  background-color: #ffd1d1 !important;
+}

--- a/Tombolo/client-reactjs/src/components/admin/workunits/dashboard/cards/TopCostlyJobs.tsx
+++ b/Tombolo/client-reactjs/src/components/admin/workunits/dashboard/cards/TopCostlyJobs.tsx
@@ -8,22 +8,107 @@ import type { ExpensiveWorkunit } from '@/services/workunitDashboard.service';
 import clustersService from '@/services/clusters.service';
 import { handleError } from '@/components/common/handleResponse';
 import WorkunitOpenOptionsModal from '@/components/admin/workunits/history/common/WorkunitOpenOptionsModal';
+import { getDashboardFailedRowClass } from './workunitRowStyles';
 import styles from './TopCostlyJobs.module.css';
 
 interface TopCostlyJobsProps {
   workunits: ExpensiveWorkunit[];
 }
 
-interface JobGroup {
+export interface JobGroup {
   key: string;
   groupName: string;
   count: number;
+  isNoJobNameSingleton: boolean;
+  stateLabel: string;
   totalCost: number;
   executeCost: number;
   fileAccessCost: number;
   compileCost: number;
   workunits: ExpensiveWorkunit[];
 }
+
+const stateColors: Record<string, string> = {
+  completed: 'green',
+  failed: 'red',
+  running: 'blue',
+  blocked: 'orange',
+  waiting: 'default',
+  mixed: 'default',
+  unknown: 'default',
+};
+
+export const formatStateLabel = (state?: string): string => {
+  if (!state) return 'Unknown';
+  if (state === 'mixed') return 'Mixed';
+  return state.charAt(0).toUpperCase() + state.slice(1);
+};
+
+export const getGroupStateLabel = (workunits: ExpensiveWorkunit[]): string => {
+  const states = workunits
+    .map(wu => wu.state?.toLowerCase())
+    .filter((state): state is string => Boolean(state && state.trim()));
+
+  if (states.length === 0) {
+    return 'unknown';
+  }
+
+  const uniqueStates = new Set(states);
+  if (uniqueStates.size === 1) {
+    return states[0];
+  }
+
+  return 'mixed';
+};
+
+const buildJobGroup = (
+  groupName: string,
+  workunitArray: ExpensiveWorkunit[],
+  key: string,
+  isNoJobNameSingleton = false
+): JobGroup => {
+  const totalCost = workunitArray.reduce((sum, wu) => sum + (wu.totalCost || 0), 0);
+  const executeCost = workunitArray.reduce((sum, wu) => sum + (wu.executeCost || 0), 0);
+  const fileAccessCost = workunitArray.reduce((sum, wu) => sum + (wu.fileAccessCost || 0), 0);
+  const compileCost = workunitArray.reduce((sum, wu) => sum + (wu.compileCost || 0), 0);
+
+  return {
+    key,
+    groupName,
+    count: workunitArray.length,
+    isNoJobNameSingleton,
+    stateLabel: getGroupStateLabel(workunitArray),
+    totalCost,
+    executeCost,
+    fileAccessCost,
+    compileCost,
+    workunits: [...workunitArray].sort(
+      (a, b) => new Date(b.workUnitTimestamp).getTime() - new Date(a.workUnitTimestamp).getTime()
+    ),
+  };
+};
+
+export const buildJobGroupsForTopCostlyJobs = (workunits: ExpensiveWorkunit[]): JobGroup[] => {
+  if (!workunits || workunits.length === 0) {
+    return [];
+  }
+
+  const namedWorkunits = workunits.filter(wu => typeof wu.jobName === 'string' && wu.jobName.trim().length > 0);
+  const unnamedWorkunits = workunits.filter(wu => typeof wu.jobName !== 'string' || wu.jobName.trim().length === 0);
+
+  const groupedNamedWorkunits = groupWorkunitsByName(namedWorkunits, 0.8);
+
+  const namedGroups: JobGroup[] = Object.entries(groupedNamedWorkunits).map(([groupName, wus]) => {
+    const workunitArray = wus as ExpensiveWorkunit[];
+    return buildJobGroup(groupName || 'Unnamed', workunitArray, groupName || 'unnamed-group');
+  });
+
+  const unnamedGroups: JobGroup[] = unnamedWorkunits.map((wu, index) =>
+    buildJobGroup(wu.wuId || `Workunit-${index + 1}`, [wu], `unnamed-${wu.wuId || index}`, true)
+  );
+
+  return [...namedGroups, ...unnamedGroups].sort((a, b) => b.totalCost - a.totalCost);
+};
 
 // Cost breakdown bar component
 const CostBreakdownBar = ({
@@ -99,35 +184,7 @@ export default function TopCostlyJobs({ workunits }: TopCostlyJobsProps) {
 
   // Group workunits using fuzzy matching and aggregate costs
   const jobGroups = useMemo(() => {
-    if (!workunits || workunits.length === 0) return [];
-
-    // Use fuzzy matching to group similar job names (client-side)
-    const grouped = groupWorkunitsByName(workunits, 0.8);
-
-    // Convert to array format and aggregate costs
-    const groups: JobGroup[] = Object.entries(grouped).map(([groupName, wus]) => {
-      const workunitArray = wus as ExpensiveWorkunit[];
-      const totalCost = workunitArray.reduce((sum, wu) => sum + (wu.totalCost || 0), 0);
-      const executeCost = workunitArray.reduce((sum, wu) => sum + (wu.executeCost || 0), 0);
-      const fileAccessCost = workunitArray.reduce((sum, wu) => sum + (wu.fileAccessCost || 0), 0);
-      const compileCost = workunitArray.reduce((sum, wu) => sum + (wu.compileCost || 0), 0);
-
-      return {
-        key: groupName,
-        groupName: groupName || 'Unnamed',
-        count: workunitArray.length,
-        totalCost,
-        executeCost,
-        fileAccessCost,
-        compileCost,
-        workunits: workunitArray.sort(
-          (a, b) => new Date(b.workUnitTimestamp).getTime() - new Date(a.workUnitTimestamp).getTime()
-        ),
-      };
-    });
-
-    // Sort by total cost descending
-    return groups.sort((a, b) => b.totalCost - a.totalCost);
+    return buildJobGroupsForTopCostlyJobs(workunits);
   }, [workunits]);
 
   const displayedGroups = jobGroups.slice(0, visibleCount);
@@ -154,8 +211,18 @@ export default function TopCostlyJobs({ workunits }: TopCostlyJobsProps) {
       render: (text: string, record: JobGroup) => (
         <Space size={4} align="center">
           <span className={styles.jobNameGroup}>{text}</span>
+          {record.isNoJobNameSingleton && <Tag>No Job Name</Tag>}
           <Tag color="blue">{record.count}</Tag>
         </Space>
+      ),
+    },
+    {
+      title: 'State',
+      dataIndex: 'stateLabel',
+      key: 'stateLabel',
+      width: 110,
+      render: (stateLabel: string) => (
+        <Tag color={stateColors[stateLabel] || 'default'}>{formatStateLabel(stateLabel)}</Tag>
       ),
     },
     {
@@ -220,6 +287,13 @@ export default function TopCostlyJobs({ workunits }: TopCostlyJobsProps) {
       key: 'owner',
       width: 100,
       ellipsis: true,
+    },
+    {
+      title: 'State',
+      dataIndex: 'state',
+      key: 'state',
+      width: 100,
+      render: (state: string) => <Tag color={stateColors[state] || 'default'}>{formatStateLabel(state)}</Tag>,
     },
     {
       title: 'Cost',
@@ -308,6 +382,7 @@ export default function TopCostlyJobs({ workunits }: TopCostlyJobsProps) {
               size="small"
               rowKey="wuId"
               className={styles.nestedTable}
+              rowClassName={nestedRecord => getDashboardFailedRowClass(nestedRecord.state)}
             />
           ),
           rowExpandable: () => true,

--- a/Tombolo/client-reactjs/src/components/admin/workunits/dashboard/cards/WorkunitTable.tsx
+++ b/Tombolo/client-reactjs/src/components/admin/workunits/dashboard/cards/WorkunitTable.tsx
@@ -8,6 +8,7 @@ import workunitsService from '@/services/workunits.service';
 import clustersService from '@/services/clusters.service';
 import WorkunitOpenOptionsModal from '@/components/admin/workunits/history/common/WorkunitOpenOptionsModal';
 import { handleError } from '@/components/common/handleResponse';
+import { getDashboardFailedRowClass } from './workunitRowStyles';
 
 export interface CostBreakdown {
   compute: number;
@@ -471,6 +472,7 @@ export default function WorkunitTable({ startDate, endDate, clusterId }: Workuni
         dataSource={data}
         loading={loading}
         rowKey={record => `${record.clusterId}:${record.wuid}`}
+        rowClassName={record => getDashboardFailedRowClass(record.state)}
         size="small"
         scroll={{ x: 1200 }}
         pagination={{

--- a/Tombolo/client-reactjs/src/components/admin/workunits/dashboard/cards/workunitRowStyles.ts
+++ b/Tombolo/client-reactjs/src/components/admin/workunits/dashboard/cards/workunitRowStyles.ts
@@ -1,0 +1,8 @@
+export const DASHBOARD_FAILED_ROW_CLASS = 'dashboard-wu-row-failed';
+
+export const getDashboardFailedRowClass = (state?: string): string => {
+  if (state === 'failed') {
+    return DASHBOARD_FAILED_ROW_CLASS;
+  }
+  return '';
+};

--- a/Tombolo/client-reactjs/src/tests/workunitAnalytics/topCostlyJobsGrouping.test.ts
+++ b/Tombolo/client-reactjs/src/tests/workunitAnalytics/topCostlyJobsGrouping.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildJobGroupsForTopCostlyJobs,
+  formatStateLabel,
+  getGroupStateLabel,
+} from '@/components/admin/workunits/dashboard/cards/TopCostlyJobs';
+import type { ExpensiveWorkunit } from '@/services/workunitDashboard.service';
+
+const makeWorkunit = (overrides: Partial<ExpensiveWorkunit>): ExpensiveWorkunit => ({
+  wuId: overrides.wuId || 'W20260423-000000',
+  jobName: Object.prototype.hasOwnProperty.call(overrides, 'jobName') ? overrides.jobName : 'Default Job',
+  clusterId: overrides.clusterId || 'cluster-1',
+  owner: overrides.owner || 'owner-a',
+  state: overrides.state || 'completed',
+  totalCost: overrides.totalCost ?? 1,
+  executeCost: overrides.executeCost ?? 1,
+  fileAccessCost: overrides.fileAccessCost ?? 0,
+  compileCost: overrides.compileCost ?? 0,
+  totalClusterTime: overrides.totalClusterTime ?? 1,
+  workUnitTimestamp: overrides.workUnitTimestamp || '2026-04-23T10:00:00.000Z',
+  detailsFetchedAt: overrides.detailsFetchedAt ?? '2026-04-23T10:01:00.000Z',
+});
+
+describe('buildJobGroupsForTopCostlyJobs', () => {
+  it('includes unnamed singles and sorts top-level rows by total cost', () => {
+    const workunits: ExpensiveWorkunit[] = [
+      makeWorkunit({ wuId: 'W1', jobName: 'Nightly ETL', totalCost: 30, state: 'completed' }),
+      makeWorkunit({ wuId: 'W2', jobName: 'Nightly ETL', totalCost: 20, state: 'failed' }),
+      makeWorkunit({ wuId: 'W3', jobName: '', totalCost: 70, state: 'failed' }),
+      makeWorkunit({ wuId: 'W4', jobName: undefined, totalCost: 5, state: 'running' }),
+    ];
+
+    const groups = buildJobGroupsForTopCostlyJobs(workunits);
+
+    expect(groups).toHaveLength(3);
+    expect(groups.map(group => group.totalCost)).toEqual([70, 50, 5]);
+    expect(groups.map(group => group.groupName)).toEqual(['W3', 'Nightly ETL', 'W4']);
+
+    expect(groups[0].count).toBe(1);
+    expect(groups[0].workunits[0].wuId).toBe('W3');
+    expect(groups[0].isNoJobNameSingleton).toBe(true);
+
+    expect(groups[1].count).toBe(2);
+    expect(groups[1].stateLabel).toBe('mixed');
+    expect(groups[1].isNoJobNameSingleton).toBe(false);
+
+    expect(groups[2].isNoJobNameSingleton).toBe(true);
+  });
+
+  it('ranks by grouped total cost, not by highest individual workunit', () => {
+    const workunits: ExpensiveWorkunit[] = [
+      makeWorkunit({ wuId: 'W10', jobName: 'Grouped Job', totalCost: 40, state: 'completed' }),
+      makeWorkunit({ wuId: 'W11', jobName: 'Grouped Job', totalCost: 35, state: 'completed' }),
+      makeWorkunit({ wuId: 'W12', jobName: undefined, totalCost: 70, state: 'failed' }),
+    ];
+
+    const groups = buildJobGroupsForTopCostlyJobs(workunits);
+
+    expect(groups[0].groupName).toBe('Grouped Job');
+    expect(groups[0].totalCost).toBe(75);
+    expect(groups[0].count).toBe(2);
+    expect(groups[0].isNoJobNameSingleton).toBe(false);
+
+    expect(groups[1].groupName).toBe('W12');
+    expect(groups[1].totalCost).toBe(70);
+    expect(groups[1].count).toBe(1);
+    expect(groups[1].isNoJobNameSingleton).toBe(true);
+  });
+});
+
+describe('group state labeling', () => {
+  it('returns mixed for mixed groups and preserves exact state for homogeneous groups', () => {
+    const mixedState = getGroupStateLabel([
+      makeWorkunit({ wuId: 'WA', state: 'completed' }),
+      makeWorkunit({ wuId: 'WB', state: 'failed' }),
+    ]);
+    const singleState = getGroupStateLabel([makeWorkunit({ wuId: 'WC', state: 'running' })]);
+
+    expect(mixedState).toBe('mixed');
+    expect(singleState).toBe('running');
+  });
+
+  it('formats state labels for display', () => {
+    expect(formatStateLabel('mixed')).toBe('Mixed');
+    expect(formatStateLabel('failed')).toBe('Failed');
+    expect(formatStateLabel(undefined)).toBe('Unknown');
+  });
+});

--- a/Tombolo/client-reactjs/src/tests/workunitAnalytics/workunitRowStyles.test.ts
+++ b/Tombolo/client-reactjs/src/tests/workunitAnalytics/workunitRowStyles.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DASHBOARD_FAILED_ROW_CLASS,
+  getDashboardFailedRowClass,
+} from '@/components/admin/workunits/dashboard/cards/workunitRowStyles';
+
+describe('getDashboardFailedRowClass', () => {
+  it('returns the dashboard failed-row class only for failed state', () => {
+    expect(getDashboardFailedRowClass('failed')).toBe(DASHBOARD_FAILED_ROW_CLASS);
+    expect(getDashboardFailedRowClass('running')).toBe('');
+    expect(getDashboardFailedRowClass('aborted')).toBe('');
+    expect(getDashboardFailedRowClass(undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## Description

Improves the top costly jobs dashboard by grouping workunits more accurately, labeling mixed and singleton groups, and adding state indicators. Failed workunits are now visually highlighted in tables, making issues easier to spot. Adds tests for grouping and row styling logic.

Fixes #1876 

## Developer's Checklist

Please select at least one

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] Breaking change (enhancement, fix, or feature that alters existing functionality)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Vulnerability fix (package updates or CodeQL adjustments to enhance code security)
- [ ] Documentation update (addition or update of documentation or helper text)
- [ ] Other change (please explain in the comment section)

#### Code Quality ( All must be selected )

- [x] I have commented on my code, especially in complex areas
- [x] I have resolved any conflicts with the target branch
- [x] My changes do not generate new warnings
- [x] I have checked my code for any misspellings
- [x] I have ensured my code does not duplicate existing code unnecessarily

#### Documentation

- [x] No documentation changes were required
- [ ] I have made corresponding changes to the documentation

#### Security

- [x] I have confirmed that all security checks (e.g., CodeQL) have passed
- [x] No user input validation was required for this change
- [ ] All user inputs have appropriate validation, including reasonable character limits

#### UX

- [ ] This change does not involve any updates to UX elements
- [x] Refreshing related pages results in a functional and logical state
- [x] Appropriate error messages are displayed when necessary

#### Testing

- [ ] Existing unit tests pass locally with my changes
- [ ] No new unit tests were necessary for my changes
- [x] I have added new unit tests for my changes

## Reviewer Checklist

- [ ] I have successfully pulled the branch into my local environment, initiated the project, and verified that all the checked items above have passed
